### PR TITLE
리뷰 관련 API 경로 수정 및 사용자 인증 정보 처리 방식 변경

### DIFF
--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -10,7 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,13 +25,14 @@ public class ReviewController {
      *
      * @param bookId           리뷰를 작성할 책의 ID
      * @param reviewRequestDto 클라이언트가 전달한 리뷰 데이터
-     * @param member           현재 인증된 사용자
+     * @param authentication   현재 인증된 사용자
      * @return 생성된 리뷰의 상세 정보를 담은 DTO
      */
     @PostMapping("/book/{bookId}/reviews")
     public ResponseEntity<ReviewResponseDto> createReview(@PathVariable Long bookId,
                                                           @RequestBody ReviewRequestDto reviewRequestDto,
-                                                          @AuthenticationPrincipal Member member) {
+                                                          Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal(); // Authentication 에서 Member 객체 추출
         ReviewResponseDto reviewResponseDto =
                 reviewService.createReview(bookId, reviewRequestDto, member);
 
@@ -76,13 +77,14 @@ public class ReviewController {
      *
      * @param reviewId         수정할 리뷰의 ID
      * @param reviewRequestDto 클라이언트가 전달한 수정 데이터
-     * @param member           현재 인증된 사용자
+     * @param authentication   현재 인증된 사용자
      * @return 수정된 리뷰의 상세 정보를 담은 DTO
      */
     @PutMapping("/review/{reviewId}")
     public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long reviewId,
                                                           @RequestBody ReviewRequestDto reviewRequestDto,
-                                                          @AuthenticationPrincipal Member member) {
+                                                          Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
         ReviewResponseDto updatedReview = reviewService.updateReview(reviewId, reviewRequestDto, member);
 
         return ResponseEntity.ok().body(updatedReview);
@@ -91,13 +93,14 @@ public class ReviewController {
     /**
      * 특정 리뷰를 삭제합니다
      *
-     * @param reviewId 삭제할 리뷰의 ID
-     * @param member   현재 인증된 사용자
+     * @param reviewId       삭제할 리뷰의 ID
+     * @param authentication 현재 인증된 사용자
      * @return 삭제 완료 메시지
      */
     @DeleteMapping("/review/{reviewId}")
     public ResponseEntity<String> deleteReview(@PathVariable Long reviewId,
-                                               @AuthenticationPrincipal Member member) {
+                                               Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
         reviewService.deleteReview(reviewId, member);
 
         return ResponseEntity.ok().body("리뷰가 성공적으로 삭제되었습니다.");

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -28,7 +28,7 @@ public class ReviewController {
      * @param authentication   현재 인증된 사용자
      * @return 생성된 리뷰의 상세 정보를 담은 DTO
      */
-    @PostMapping("/book/{bookId}/reviews")
+    @PostMapping("/books/{bookId}/reviews")
     public ResponseEntity<ReviewResponseDto> createReview(@PathVariable Long bookId,
                                                           @RequestBody ReviewRequestDto reviewRequestDto,
                                                           Authentication authentication) {
@@ -49,7 +49,7 @@ public class ReviewController {
      * @param size   한 페이지당 조회할 리뷰 개수
      * @return 해당 책의 리뷰 목록을 담은 페이징된 DTO 리스트
      */
-    @GetMapping("/book/{bookId}/reviews")
+    @GetMapping("/books/{bookId}/reviews")
     public ResponseEntity<Page<ReviewResponseDto>> getReviews(@PathVariable Long bookId,
                                                               @RequestParam("page") int page,
                                                               @RequestParam("size") int size) {
@@ -65,7 +65,7 @@ public class ReviewController {
      * @param reviewId 조회할 리뷰의 ID
      * @return 해당 리뷰의 상세 정보를 담은 DTO
      */
-    @GetMapping("/review/{reviewId}")
+    @GetMapping("/reviews/{reviewId}")
     public ResponseEntity<ReviewResponseDto> getReview(@PathVariable Long reviewId) {
         ReviewResponseDto reviewResponseDto = reviewService.getReview(reviewId);
 
@@ -80,7 +80,7 @@ public class ReviewController {
      * @param authentication   현재 인증된 사용자
      * @return 수정된 리뷰의 상세 정보를 담은 DTO
      */
-    @PutMapping("/review/{reviewId}")
+    @PutMapping("/reviews/{reviewId}")
     public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long reviewId,
                                                           @RequestBody ReviewRequestDto reviewRequestDto,
                                                           Authentication authentication) {
@@ -97,7 +97,7 @@ public class ReviewController {
      * @param authentication 현재 인증된 사용자
      * @return 삭제 완료 메시지
      */
-    @DeleteMapping("/review/{reviewId}")
+    @DeleteMapping("/reviews/{reviewId}")
     public ResponseEntity<String> deleteReview(@PathVariable Long reviewId,
                                                Authentication authentication) {
         Member member = (Member) authentication.getPrincipal();


### PR DESCRIPTION
- **변경사항**
1. **리뷰 관련 API 경로 수정**
    - RESTful API 규칙에 맞춰 복수형 경로 사용 - (`/books`, `/reviews`)로 변경
   
2. **사용자 인증 정보 처리 방식 변경**
    - `@AuthenticationPrincipal Member` 대신 `Authentication` 객체를 통해 인증된 사용자 정보를 처리하도록 수정
  
    - 컨트롤러에서 `authentication.getPrincipal()`을 사용하여 인증된 사용자 정보를 `Member` 객체로 처리

