### PR TITLE
feat : Book 상세 정보 조회할때 같은작가의 다른 책들 함께 return 하게끔 구현

### DIFF
--- a/src/main/java/com/team1/epilogue/book/dto/BookDetailResponse.java
+++ b/src/main/java/com/team1/epilogue/book/dto/BookDetailResponse.java
@@ -1,5 +1,6 @@
 package com.team1.epilogue.book.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,5 +17,6 @@ public class BookDetailResponse {
   private String description;
   private String pubDate;
   private String isbn;
+  private List<SameAuthorBookTitleIsbn> sameAuthor;
 
 }

--- a/src/main/java/com/team1/epilogue/book/dto/SameAuthorBookTitleIsbn.java
+++ b/src/main/java/com/team1/epilogue/book/dto/SameAuthorBookTitleIsbn.java
@@ -1,0 +1,14 @@
+package com.team1.epilogue.book.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class SameAuthorBookTitleIsbn {
+  private String id;
+  private String title;
+
+}

--- a/src/main/java/com/team1/epilogue/book/entity/Book.java
+++ b/src/main/java/com/team1/epilogue/book/entity/Book.java
@@ -4,6 +4,7 @@ import com.team1.epilogue.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,11 +24,17 @@ public class Book extends BaseEntity {
 
   private String author;
 
+  private Integer price;
+
   @Lob
   private String description;
 
   private double avgRating;
 
   private String coverUrl;
+
+  private String publisher;
+
+  private LocalDate pubDate;
 
 }

--- a/src/main/java/com/team1/epilogue/book/repository/BookRepository.java
+++ b/src/main/java/com/team1/epilogue/book/repository/BookRepository.java
@@ -1,10 +1,16 @@
 package com.team1.epilogue.book.repository;
 
 import com.team1.epilogue.book.entity.Book;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface BookRepository extends JpaRepository<Book,String> {
+public interface BookRepository extends JpaRepository<Book,String>{
+
+  Optional<Book> findByTitle(String title);
+
+  List<Book> findAllByAuthor(String author);
 
 }

--- a/src/main/java/com/team1/epilogue/book/service/BookService.java
+++ b/src/main/java/com/team1/epilogue/book/service/BookService.java
@@ -3,12 +3,18 @@ package com.team1.epilogue.book.service;
 import com.team1.epilogue.book.client.NaverApiClient;
 import com.team1.epilogue.book.dto.BookDetailRequest;
 import com.team1.epilogue.book.dto.BookDetailResponse;
+import com.team1.epilogue.book.dto.SameAuthorBookTitleIsbn;
 import com.team1.epilogue.book.dto.xml.BookDetailXMLResponse;
 import com.team1.epilogue.book.dto.BookInfoRequest;
 import com.team1.epilogue.book.dto.NaverBookSearchResponse;
 import com.team1.epilogue.book.dto.xml.Item;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.book.repository.BookRepository;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,20 +49,59 @@ public class BookService {
    * @return 네이버에서 온 응답값을 return
    */
   public BookDetailResponse getBookDetail(BookDetailRequest dto) {
-    BookDetailXMLResponse response = naverApiClient.getBookDetail(naverUrl, dto);
+    Optional<Book> bookOpt; // repository 에서 가져올 Optional 객체
+    Book book; // Optional 내부의 책 데이터
 
-    Item item = response.getItems().get(0);
+    if ("d_isbn".equals(dto.getType())) { // dto 의 Type 에 따라 다른 쿼리문 호출
+      bookOpt = bookRepository.findById(dto.getQuery()); // 책 ISBN 으로 DB 조회
+    } else {
+      bookOpt = bookRepository.findByTitle(dto.getQuery()); // 책 제목으로 DB 조회
+    }
+
+    // Optional 내부에 Book 데이터가 존재하지 않는다면 Naver API 호출 -> DB 에 저장
+    book = bookOpt.orElseGet(
+        () -> {
+          BookDetailXMLResponse response = naverApiClient.getBookDetail(naverUrl, dto);
+
+          Item item = response.getItems().get(0);
+
+          // DTO 로 반환 형식에 맞춰 return
+          BookDetailResponse build = BookDetailResponse.builder()
+              .title(item.getTitle())
+              .image(item.getImage())
+              .author(item.getAuthor())
+              .price(item.getPrice())
+              .publisher(item.getPublisher())
+              .description(item.getDescription())
+              .pubDate(item.getPubDate())
+              .isbn(item.getIsbn())
+              .build();
+
+          return insertBookInfo(build);
+        }
+    );
+    List<SameAuthorBookTitleIsbn> dtoList = new ArrayList<>();
+    List<Book> sameAuthorBooks = bookRepository.findAllByAuthor(book.getAuthor());
+    sameAuthorBooks.stream().forEach( // DB 에서 가져온 책들의 정보를 DTO List 로 변환
+        data -> {
+          if (data.getId() != book.getId()) { // 같은 작가의 현재 가져온 책을 제외한 다른 책들을 가져온다.
+            dtoList.add(
+                SameAuthorBookTitleIsbn.builder().title(data.getTitle()).id(data.getId()).build());
+          }
+        }
+    );
 
     // DTO 로 반환 형식에 맞춰 return
     BookDetailResponse build = BookDetailResponse.builder()
-        .title(item.getTitle())
-        .image(item.getImage())
-        .author(item.getAuthor())
-        .price(item.getPrice())
-        .publisher(item.getPublisher())
-        .description(item.getDescription())
-        .pubDate(item.getPubDate())
-        .isbn(item.getIsbn())
+        .title(book.getTitle())
+        .image(book.getCoverUrl())
+        .author(book.getAuthor())
+        .price(book.getPrice())
+        .publisher(book.getPublisher())
+        .description(book.getDescription())
+        .pubDate(Objects.toString(book.getPubDate(), ""))
+        .isbn(book.getId())
+        .sameAuthor(dtoList)
         .build();
 
     return build;
@@ -74,9 +119,14 @@ public class BookService {
         .id(dto.getIsbn())
         .title(dto.getTitle())
         .author(dto.getAuthor())
+        .price(dto.getPrice())
         .description(dto.getDescription())
         .avgRating(0.0)
         .coverUrl(dto.getImage())
+        .publisher(dto.getPublisher())
+        .pubDate(Optional.ofNullable(dto.getPubDate())
+            .map(LocalDate::parse)
+            .orElse(null)) // null이면 그대로 null 할당
         .build();
 
     return bookRepository.save(book);


### PR DESCRIPTION
- **변경사항**
    - 기존 Book 상세 정보 보기 기능 -> Naver API 를 바로 호출해 데이터를 응답했습니다.
    - 수정된 Book 상세 정보 보기 기능 -> DB 를 우선적으로 조회 후 , 존재하지 않을땐 Naver API 를 호출.
      호출에 대한 response 를 DB 에 save합니다. 그 뒤 그 값을 응답합니다.

## 응답값 예시
```
{
    "title": "데미안",
    "image": "https://shopping-phinf.pstatic.net/main_4177277/41772770620.20230815075820.jpg",
    "author": "헤르만헤세",
    "price": 0,
    "publisher": "범우",
    "description": "독일작가 헤르만 헤세의 소설\n\n이 책은 노벨문학상 수상작가 헤르만 헤세가 제1차 세계대전 직후 익명으로 발표하여 센세이션을 불러 일으켰던 소설이다. \n  신앙이 깊고 성결하며 예의바른 부모의 세계와 하녀 장인들의 입을 통해 듣는 부랑자 ㆍ 주정뱅이 ㆍ 강도 등 악의 세계가 자신의 내면에서 대립되고 있어, 위태로운 방황을 계속하던 주인공 싱클레어가 ‘데미안’이라는 수수께끼의 소년에 의하여 자기발견의 길로 인도되어 참된 자아를 찾는 과정을 그리고 있다. \n  전쟁 후 정신적인 폐허 속에서 헤매던 당시 독일의 젊은이들뿐 아니라 오늘의 젊은 영혼들의 길까지 밝혀줄 헤세의 명작이다.",
    "pubDate": "",
    "isbn": "9788963655253",
    "sameAuthor": [
        {
            "id": "9788952246929",
            "title": "게르트루트"
        },
        {
            "id": "9791162337219",
            "title": "수레바퀴 밑에서 (너의 수레에는 뭘 싣고 싶은지 생각해 봐!)"
        }
    ]
}
```
sameAuthor 이름의 배열을 추가했습니다.
배열 내부에는 DB 내부에 존재하는 같은 작가의 다른책들의 정보를 담아 함께 return 합니다.
위 예시는 "데미안" 이라는 책의 상세 정보 조회를 한 예시이고,
sameAuthor 배열 내부에는 DB 내부의 존재하는 "헤르만헤세" 작가의 다른 책들이 담겨 return 된결과입니다.

- **리뷰 요청 사항**
    - 책 상세보기 기능에 대한 코드리뷰를 부탁합니다.
    - DB 에 존재하지 않는 책 조회 -> 네이버 호출 -> DB 저장 -> 저장된 값 응답
    위 흐름의 개발 방식이 적절한지 검토 부탁드립니다.

- **관련된 이슈**
    - #3 
   close #3
