### PR TITLE
refactor : Point 거래 관련 DB Lock 추가.

### DIFF
--- a/src/main/java/com/team1/epilogue/auth/repository/MemberRepository.java
+++ b/src/main/java/com/team1/epilogue/auth/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.team1.epilogue.auth.repository;
 
 import com.team1.epilogue.auth.entity.Member;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -48,4 +50,15 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      * @return 존재하면 true, 없으면 false를 반환
      */
     boolean existsByEmail(String email);
+
+    /**
+     * 사용자 정보 Lock 을 걸기위한 메서드. 이 메서드로 호출한 Member 정보는 해당 작업이 끝날때까지
+     * <쓰기> 에 대한 접근이 제한된다.
+     *
+     * @param loginId 사용자 ID
+     * @param lock 메서드 오버로딩을 위한 변수
+     * @return 사용자 정보를 Optional 에 담아 return
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Member> findByLoginId(String loginId,boolean lock);
 }

--- a/src/main/java/com/team1/epilogue/transaction/service/TransactionService.java
+++ b/src/main/java/com/team1/epilogue/transaction/service/TransactionService.java
@@ -36,7 +36,7 @@ public class TransactionService {
   @Transactional
   public void updateBalance(String memberId, int amount, TransactionDetail detail, String tid) {
     // 사용자 정보 가져오기 존재하지않다면 Exception
-    Member member = memberRepository.findByLoginId(memberId)
+    Member member = memberRepository.findByLoginId(memberId,true)
         .orElseThrow(() -> new MemberNotFoundException());
 
     // 거래정보 저장을 위한 Transaction 객체 생성

--- a/src/main/java/com/team1/epilogue/transaction/service/TransactionService.java
+++ b/src/main/java/com/team1/epilogue/transaction/service/TransactionService.java
@@ -36,7 +36,7 @@ public class TransactionService {
   @Transactional
   public void updateBalance(String memberId, int amount, TransactionDetail detail, String tid) {
     // 사용자 정보 가져오기 존재하지않다면 Exception
-    Member member = memberRepository.findByLoginId(memberId,true)
+    Member member = memberRepository.findByLoginId(memberId,true) // // 파라미터로 true 변수를 주어 '쓰기' 에 대해 Lock
         .orElseThrow(() -> new MemberNotFoundException());
 
     // 거래정보 저장을 위한 Transaction 객체 생성


### PR DESCRIPTION
- **변경사항**
    - MemberRepository 내부에 findByMemberId() 메서드를 오버로딩 방식으로 추가하였습니다.
 ```
@Repository
public interface MemberRepository extends JpaRepository<Member, Long> {

    /**
     * [메서드 레벨]
     * findByLoginId 메서드는 주어진 loginId에 해당하는 Member 엔티티를 조회
     *
     * @param loginId 회원의 로그인 ID
     * @return Optional<Member> 객체로, 해당 회원이 존재하면 값을 포함하고, 없으면 비어있음
     */
    Optional<Member> findByLoginId(String loginId);
    
    /**
     * 사용자 정보 Lock 을 걸기위한 메서드. 이 메서드로 호출한 Member 정보는 해당 작업이 끝날때까지
     * <쓰기> 에 대한 접근이 제한된다.
     *
     * @param loginId 사용자 ID
     * @param lock 메서드 오버로딩을 위한 변수
     * @return 사용자 정보를 Optional 에 담아 return
     */
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    Optional<Member> findByLoginId(String loginId,boolean lock);
    
   }
```
 - 메서드명이 동일한 2가지의 메서드가 존재하게됩니다.
 - Write 에 대해 Lock 이 필요한 작업은 findByLoginId(memberId,true) <- 와 같이 파라미터로 boolean 변수를 추가해주면 됩니다.
 - 그 외에 작업에서는 기존 방식과 동일하게 findByLoginId(memberId) <- 로 사용하시면 되겠습니다.
 
---

- **리뷰 요청 사항**
    - 코드 한번 읽어보시고 두가지 메서드 구분해주시기바랍니다.

---

- **관련된 이슈**
    - #24 
