### PR TITLE
Member와 Book 엔티티의 Rating 연관 관계 설정 및 별점 서비스 구현

### DIFF
--- a/src/main/java/com/team1/epilogue/auth/entity/Member.java
+++ b/src/main/java/com/team1/epilogue/auth/entity/Member.java
@@ -1,6 +1,7 @@
 package com.team1.epilogue.auth.entity;
 
 import com.team1.epilogue.common.entity.BaseEntity;
+import com.team1.epilogue.rating.entity.Rating;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,6 +9,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.Setter;
 
 /**
@@ -102,5 +106,7 @@ public class Member extends BaseEntity {
      */
     @Column
     private String social;
-
+    
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    private List<Rating> ratings = new ArrayList<>();;;
 }

--- a/src/main/java/com/team1/epilogue/auth/entity/Member.java
+++ b/src/main/java/com/team1/epilogue/auth/entity/Member.java
@@ -106,7 +106,7 @@ public class Member extends BaseEntity {
      */
     @Column
     private String social;
-    
+
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    private List<Rating> ratings = new ArrayList<>();;;
+    private List<Rating> ratings = new ArrayList<>();
 }

--- a/src/main/java/com/team1/epilogue/auth/entity/Member.java
+++ b/src/main/java/com/team1/epilogue/auth/entity/Member.java
@@ -106,7 +106,4 @@ public class Member extends BaseEntity {
      */
     @Column
     private String social;
-
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    private List<Rating> ratings = new ArrayList<>();
 }

--- a/src/main/java/com/team1/epilogue/book/entity/Book.java
+++ b/src/main/java/com/team1/epilogue/book/entity/Book.java
@@ -1,10 +1,13 @@
 package com.team1.epilogue.book.entity;
 
 import com.team1.epilogue.common.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
+import com.team1.epilogue.rating.entity.Rating;
+import jakarta.persistence.*;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -37,4 +40,6 @@ public class Book extends BaseEntity {
 
   private LocalDate pubDate;
 
+  @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
+  private List<Rating> ratings = new ArrayList<>();;
 }

--- a/src/main/java/com/team1/epilogue/book/entity/Book.java
+++ b/src/main/java/com/team1/epilogue/book/entity/Book.java
@@ -39,7 +39,4 @@ public class Book extends BaseEntity {
   private String publisher;
 
   private LocalDate pubDate;
-
-  @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
-  private List<Rating> ratings = new ArrayList<>();
 }

--- a/src/main/java/com/team1/epilogue/book/entity/Book.java
+++ b/src/main/java/com/team1/epilogue/book/entity/Book.java
@@ -41,5 +41,5 @@ public class Book extends BaseEntity {
   private LocalDate pubDate;
 
   @OneToMany(mappedBy = "book", fetch = FetchType.LAZY)
-  private List<Rating> ratings = new ArrayList<>();;
+  private List<Rating> ratings = new ArrayList<>();
 }

--- a/src/main/java/com/team1/epilogue/rating/controller/RatingController.java
+++ b/src/main/java/com/team1/epilogue/rating/controller/RatingController.java
@@ -1,0 +1,73 @@
+package com.team1.epilogue.rating.controller;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.rating.dto.RatingRequestDto;
+import com.team1.epilogue.rating.dto.RatingResponseDto;
+import com.team1.epilogue.rating.service.RatingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class RatingController {
+
+    private final RatingService ratingService;
+
+    /**
+     * 책에 대한 별점을 생성하거나 수정합니다
+     *
+     * @param bookId           별점을 남길 책의 ID
+     * @param ratingRequestDto 클라이언트가 전달한 별점 데이터
+     * @param authentication   현재 인증된 사용자
+     * @return 생성된 별점의 상세 정보를 담은 DTO
+     */
+    @PostMapping("/books/{bookId}/ratings")
+    public ResponseEntity<RatingResponseDto> createRating(@PathVariable String bookId,
+                                                          @RequestBody @Valid RatingRequestDto ratingRequestDto,
+                                                          Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        RatingResponseDto ratingResponseDto =
+                ratingService.createRating(bookId, ratingRequestDto, member);
+
+        return ResponseEntity.ok().body(ratingResponseDto);
+    }
+
+    /**
+     * 책에 대한 별점을 수정합니다
+     *
+     * @param bookId           별점을 수정할 책의 ID
+     * @param ratingRequestDto 클라이언트가 전달한 수정된 별점 데이터
+     * @param authentication   현재 인증된 사용자
+     * @return 수정된 별점의 상세 정보를 담은 DTO
+     */
+    @PutMapping("/books/{bookId}/ratings")
+    public ResponseEntity<RatingResponseDto> updateRating(@PathVariable String bookId,
+                                                          @RequestBody RatingRequestDto ratingRequestDto,
+                                                          Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        RatingResponseDto ratingResponseDto =
+                ratingService.updateRating(bookId, ratingRequestDto, member);
+
+        return ResponseEntity.ok().body(ratingResponseDto);
+    }
+
+    /**
+     * 책에 대한 별점을 삭제합니다
+     *
+     * @param bookId         별점을 삭제할 책의 ID
+     * @param authentication 현재 인증된 사용자
+     * @return 삭제 완료 메시지
+     */
+    @DeleteMapping("/books/{bookId}/ratings")
+    public ResponseEntity<String> deleteRating(@PathVariable String bookId,
+                                               Authentication authentication) {
+        Member member = (Member) authentication.getPrincipal();
+        ratingService.deleteRating(bookId, member);
+
+        return ResponseEntity.ok().body("별점이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
+++ b/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
@@ -1,0 +1,30 @@
+package com.team1.epilogue.rating.dto;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.book.entity.Book;
+import com.team1.epilogue.rating.entity.Rating;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RatingRequestDto {
+
+    @DecimalMin("0.5")
+    @DecimalMax("5")
+    private Double score;  // 1~5 사이의 점수를 받습니다
+
+    public Rating toEntity(Book book, Member member) {
+        return Rating.builder()
+                .score(score)
+                .book(book)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
+++ b/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
@@ -18,7 +18,7 @@ public class RatingRequestDto {
 
     @DecimalMin("0.5")
     @DecimalMax("5")
-    private Double score;  // 1~5 사이의 점수를 받습니다
+    private Double score;  // 0.5 ~ 5 사이의 점수를 받습니다
 
     public Rating toEntity(Book book, Member member) {
         return Rating.builder()

--- a/src/main/java/com/team1/epilogue/rating/dto/RatingResponseDto.java
+++ b/src/main/java/com/team1/epilogue/rating/dto/RatingResponseDto.java
@@ -1,0 +1,28 @@
+package com.team1.epilogue.rating.dto;
+
+import com.team1.epilogue.rating.entity.Rating;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RatingResponseDto {
+    private Long id;            // 별점 ID
+    private String bookId;      // 책 ID
+    private Long memberId;      // 사용자 ID
+    private Double score;       // 별점
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static RatingResponseDto from(Rating rating) {
+        return RatingResponseDto.builder()
+                .id(rating.getId())
+                .bookId(rating.getBook().getId())
+                .memberId(rating.getMember().getId())
+                .score(rating.getScore())
+                .createdAt(rating.getCreatedAt())
+                .modifiedAt(rating.getModifiedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/team1/epilogue/rating/entity/Rating.java
+++ b/src/main/java/com/team1/epilogue/rating/entity/Rating.java
@@ -31,7 +31,7 @@ public class Rating extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;  // 별점을 작성한 사용자
 
-    private Double score;   // 별점 (1~5)
+    private Double score;   // 별점 (0.5 ~ 5)
 
     /**
      * 별점을 업데이트합니다

--- a/src/main/java/com/team1/epilogue/rating/entity/Rating.java
+++ b/src/main/java/com/team1/epilogue/rating/entity/Rating.java
@@ -1,0 +1,44 @@
+package com.team1.epilogue.rating.entity;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.book.entity.Book;
+import com.team1.epilogue.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Rating extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;    // 별점 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;  // 해당 별점이 속한 책
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;  // 별점을 작성한 사용자
+
+    private Double score;   // 별점 (1~5)
+
+    /**
+     * 별점을 업데이트합니다
+     *
+     * @param score 새로운 별점
+     */
+    public void updateScore(Double score) {
+        this.score = score;
+    }
+}

--- a/src/main/java/com/team1/epilogue/rating/exception/RatingNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/rating/exception/RatingNotFoundException.java
@@ -1,0 +1,8 @@
+package com.team1.epilogue.rating.exception;
+
+public class RatingNotFoundException extends RuntimeException {
+
+    public RatingNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team1/epilogue/rating/repository/RatingRepository.java
+++ b/src/main/java/com/team1/epilogue/rating/repository/RatingRepository.java
@@ -1,0 +1,17 @@
+package com.team1.epilogue.rating.repository;
+
+import com.team1.epilogue.rating.entity.Rating;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface RatingRepository extends JpaRepository<Rating, Long> {
+
+    /**
+     * 특정 책에 대해 특정 사용자가 작성한 별점을 조회합니다
+     *
+     * @param memberId 책에 별점을 남긴 사용자의 ID
+     * @param bookId   해당 책의 ID
+     * @return 해당 책에 사용자가 남긴 별점 정보가 담긴 Optional 객체
+     */
+    Optional<Rating> findByMemberIdAndBookId(Long memberId, String bookId);
+}

--- a/src/main/java/com/team1/epilogue/rating/service/RatingService.java
+++ b/src/main/java/com/team1/epilogue/rating/service/RatingService.java
@@ -33,9 +33,9 @@ public class RatingService {
                 .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
 
         Rating rating = ratingRequestDto.toEntity(book, member);
-        ratingRepository.save(rating);
+        Rating savedRating = ratingRepository.save(rating);
 
-        return RatingResponseDto.from(rating);
+        return RatingResponseDto.from(savedRating);
     }
 
     /**
@@ -52,9 +52,9 @@ public class RatingService {
                 .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
 
         rating.updateScore(ratingRequestDto.getScore());
-        ratingRepository.save(rating);
+        Rating updatedRating = ratingRepository.save(rating);
 
-        return RatingResponseDto.from(rating);
+        return RatingResponseDto.from(updatedRating);
     }
 
     /**

--- a/src/main/java/com/team1/epilogue/rating/service/RatingService.java
+++ b/src/main/java/com/team1/epilogue/rating/service/RatingService.java
@@ -1,0 +1,73 @@
+package com.team1.epilogue.rating.service;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.book.entity.Book;
+import com.team1.epilogue.book.repository.BookRepository;
+import com.team1.epilogue.rating.dto.RatingRequestDto;
+import com.team1.epilogue.rating.dto.RatingResponseDto;
+import com.team1.epilogue.rating.entity.Rating;
+import com.team1.epilogue.rating.exception.RatingNotFoundException;
+import com.team1.epilogue.rating.repository.RatingRepository;
+import com.team1.epilogue.review.exception.BookNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RatingService {
+
+    private final RatingRepository ratingRepository;
+    private final BookRepository bookRepository;
+
+    /**
+     * 책에 대한 별점을 생성합니다
+     *
+     * @param bookId           별점을 남길 책의 ID
+     * @param ratingRequestDto 클라이언트가 전달한 별점 데이터
+     * @param member           현재 인증된 사용자
+     * @return 생성된 별점의 상세 정보를 담은 DTO
+     */
+    public RatingResponseDto createRating(String bookId, RatingRequestDto ratingRequestDto, Member member) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
+
+        Rating rating = ratingRequestDto.toEntity(book, member);
+        ratingRepository.save(rating);
+
+        return RatingResponseDto.from(rating);
+    }
+
+    /**
+     * 책에 대한 별점을 수정합니다
+     *
+     * @param bookId           별점을 수정할 책의 ID
+     * @param ratingRequestDto 수정된 별점 데이터
+     * @param member           현재 인증된 사용자
+     * @return 수정된 별점의 상세 정보를 담은 DTO
+     */
+    @Transactional
+    public RatingResponseDto updateRating(String bookId, RatingRequestDto ratingRequestDto, Member member) {
+        Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
+                .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
+
+        rating.updateScore(ratingRequestDto.getScore());
+        ratingRepository.save(rating);
+
+        return RatingResponseDto.from(rating);
+    }
+
+    /**
+     * 책에 대한 별점을 삭제합니다
+     *
+     * @param bookId 별점을 삭제할 책의 ID
+     * @param member 현재 인증된 사용자
+     */
+    @Transactional
+    public void deleteRating(String bookId, Member member) {
+        Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
+                .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
+
+        ratingRepository.delete(rating);
+    }
+}

--- a/src/main/java/com/team1/epilogue/review/exception/ReviewExceptionHandler.java
+++ b/src/main/java/com/team1/epilogue/review/exception/ReviewExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.team1.epilogue.review.exception;
 
+import com.team1.epilogue.rating.exception.RatingNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -33,5 +34,13 @@ public class ReviewExceptionHandler {
     @ExceptionHandler(UnauthorizedReviewAccessException.class)
     public ResponseEntity<String> handleUnauthorizedReviewAccessException(UnauthorizedReviewAccessException e) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+    }
+
+    /**
+     * 해당 별점을 찾을 수 없을 때 예외 처리
+     */
+    @ExceptionHandler(RatingNotFoundException.class)
+    public ResponseEntity<String> handleRatingNotFoundException(RatingNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
 }

--- a/src/test/java/com/team1/epilogue/rating/RatingServiceTest.java
+++ b/src/test/java/com/team1/epilogue/rating/RatingServiceTest.java
@@ -1,0 +1,137 @@
+package com.team1.epilogue.rating;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.book.entity.Book;
+import com.team1.epilogue.book.repository.BookRepository;
+import com.team1.epilogue.rating.dto.RatingRequestDto;
+import com.team1.epilogue.rating.dto.RatingResponseDto;
+import com.team1.epilogue.rating.entity.Rating;
+import com.team1.epilogue.rating.exception.RatingNotFoundException;
+import com.team1.epilogue.rating.repository.RatingRepository;
+import com.team1.epilogue.rating.service.RatingService;
+import com.team1.epilogue.review.exception.BookNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+public class RatingServiceTest {
+
+    @InjectMocks
+    private RatingService ratingService;
+
+    @Mock
+    private RatingRepository ratingRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    private Member member;
+    private Book book;
+    private RatingRequestDto ratingRequestDto;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        member = new Member(); // 테스트용 Member 객체 생성
+        book = new Book(); // 테스트용 Book 객체 생성
+        ratingRequestDto = new RatingRequestDto(4.5); // 테스트용 RatingRequestDto 객체 생성
+    }
+
+    /**
+     * 별점 생성 테스트
+     * bookId로 책을 찾고, 별점을 4.5로 저장한 후, 해당 별점이 제대로 반환되는지 확인합니다
+     */
+    @Test
+    void createRating() {
+        // given
+        when(bookRepository.findById("bookId")).thenReturn(java.util.Optional.of(book));
+        when(ratingRepository.save(argThat(rating -> rating.getScore().equals(4.5))))
+                .thenReturn(new Rating(1L, book, member, 4.5));
+
+        // when
+        RatingResponseDto response = ratingService.createRating("bookId", ratingRequestDto, member);
+
+        // then
+        assertNotNull(response);
+        assertEquals(4.5, response.getScore());
+        verify(ratingRepository, times(1)).save(argThat(rating -> rating.getScore().equals(4.5)));
+    }
+
+    /**
+     * 별점 수정 테스트
+     * 기존 별점(2.0)을 4.5로 업데이트한 후, 업데이트된 별점이 정상적으로 반환되는지 확인합니다
+     */
+    @Test
+    void updateRating() {
+        // given
+        Rating existingRating = new Rating(1L, book, member, 2.0);
+        when(ratingRepository.findByMemberIdAndBookId(member.getId(), "bookId")).thenReturn(java.util.Optional.of(existingRating));
+
+        // when
+        RatingResponseDto response = ratingService.updateRating("bookId", ratingRequestDto, member);
+
+        // then
+        assertNotNull(response);
+        assertEquals(4.5, response.getScore());
+        verify(ratingRepository, times(1)).save(argThat(rating -> rating.getScore().equals(4.5)));
+    }
+
+    /**
+     * 별점 삭제 테스트
+     */
+    @Test
+    void deleteRating() {
+        // given
+        Rating existingRating = new Rating(1L, book, member, 3.0);
+        when(ratingRepository.findByMemberIdAndBookId(member.getId(), "bookId")).thenReturn(java.util.Optional.of(existingRating));
+
+        // when
+        ratingService.deleteRating("bookId", member);
+
+        // then
+        verify(ratingRepository, times(1)).delete(existingRating);
+    }
+
+    /**
+     * 책이 존재하지 않는 경우 별점 생성 시 예외 발생 테스트
+     */
+    @Test
+    void createRating_BookNotFound() {
+        // given
+        when(bookRepository.findById("bookId")).thenReturn(java.util.Optional.empty());
+
+        // when, then
+        assertThrows(BookNotFoundException.class, () -> ratingService.createRating("bookId", ratingRequestDto, member));
+    }
+
+    /**
+     * 별점이 존재하지 않는 경우 별점 수정 시 예외 발생 테스트
+     */
+    @Test
+    void updateRating_RatingNotFound() {
+        // given
+        when(ratingRepository.findByMemberIdAndBookId(member.getId(), "bookId")).thenReturn(java.util.Optional.empty());
+
+        // when, then
+        assertThrows(RatingNotFoundException.class, () -> ratingService.updateRating("bookId", ratingRequestDto, member));
+    }
+
+    /**
+     * 별점이 존재하지 않는 경우 별점 삭제 시 예외 발생 테스트
+     */
+    @Test
+    void deleteRating_RatingNotFound() {
+        // given
+        when(ratingRepository.findByMemberIdAndBookId(member.getId(), "bookId")).thenReturn(java.util.Optional.empty());
+
+        // when, then
+        assertThrows(RatingNotFoundException.class, () -> ratingService.deleteRating("bookId", member));
+    }
+}


### PR DESCRIPTION
## **변경사항**

### **별점 생성, 수정, 삭제 API**

- 사용자가 책에 대해 별점을 생성, 수정, 삭제할 수 있는 기능을 추가했습니다

### 별점과의 연관 관계

- `Member`와 `Book` 엔티티에 `OneToMany` 관계를 추가하여, 각각 여러 개의 별점을 가질 수 있도록 했습니다

### **별점 서비스 단위 테스트**

- 별점 서비스의 동작을 검증하는 단위 테스트를 작성하여, 기능이 정상적으로 동작하는지 확인했습니다

<br>

### ⚙[리팩토링 및 주석 수정]

### **주석 수정 및 코드 정리**
- 불필요한 세미콜론을 제거하여 코드 정리를 했습니다
- 별점 범위 주석을 **0.5 ~ 5**로 수정하여, 정확한 점수 범위에 대해 명시했습니다

### **별점 생성, 수정 API 수정**
- `'Rating' 객체를 생성하고 수정된 후, DB에서 반환된 객체를 사용하여 응답을 반환하도록 수정했습니다

### **양방향 연관 관계 삭제**
- `Member`와 `Book` 엔티티에서 `Rating`과의 양방향 연관 관계(`@OneToMany`)를 삭제했습니다
- `Rating`에서만 `Member`와 `Book`을 참조하는 방식으로 수정하여, 코드 간결화 및 성능 최적화했습니다

<br>

## **연관 관계 설명**

- **`Member`와 `Book` 엔티티에서 `Rating`과의 연관 관계를 설정**하였습니다
  - **`Member` 엔티티**에서는 **`@OneToMany`** 관계를 사용하여, 하나의 `Member`가 여러 개의 `Rating`을 가질 수 있도록 했습니다
  - **`Book` 엔티티**에서는 **`@OneToMany`** 관계를 사용하여, 하나의 `Book`이 여러 개의 `Rating`을 가질 수 있도록 했습니다
  - **`Rating` 엔티티**에서는 **`@ManyToOne`** 관계를 사용하여 `Member`와 `Book`을 각각 참조하도록 설정하였습니다
 
    - **`Rating` 객체가 하나의 `Member`와 하나의 `Book`에 속하도록** 하기 위함입니다
  
✅ 관계정리
- `Member`와 `Rating`은 **1:N 관계**로, **하나의 회원**이 여러 개의 **별점**을 작성할 수 있습니다
- `Rating`과 `Member`는 **N:1 관계**로, 각 **별점**은 **하나의 회원**에 속합니다
- `Rating`과 `Book`은 **N:1 관계**로, 각 **별점**은 **하나의 책**에 속합니다

<br>

## **관련된 이슈**

- #38 