### PR TITLE
리뷰 API 리팩토링 및 불필요한 검증 삭제

### DIFF
--- a/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
@@ -24,7 +24,7 @@ public class ReviewResponseDto {
      * @param review 변환할 Review 엔티티
      * @return 변환된 ReviewResponseDto 객체
      */
-    public static ReviewResponseDto of(Review review) {
+    public static ReviewResponseDto from(Review review) {
         return ReviewResponseDto.builder()
                 .id(review.getId())
                 .content(review.getContent())

--- a/src/main/java/com/team1/epilogue/review/service/ReviewService.java
+++ b/src/main/java/com/team1/epilogue/review/service/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
         Review review = reviewRequestDto.toEntity(book, member);
         reviewRepository.save(review);
 
-        return ReviewResponseDto.of(review);
+        return ReviewResponseDto.from(review);
     }
 
     /**
@@ -49,12 +49,11 @@ public class ReviewService {
      * @param pageable 페이징 및 정렬 정보
      * @return 해당 책의 리뷰 목록을 담은 페이징된 DTO 리스트
      */
-    @Transactional(readOnly = true)
     public Page<ReviewResponseDto> getReviews(String bookId, Pageable pageable) {
         // 좋아요순, 최신순 추가 예정
         Page<Review> reviews = reviewRepository.findByBookId(bookId, pageable);
 
-        return reviews.map(ReviewResponseDto::of);
+        return reviews.map(ReviewResponseDto::from);
     }
 
     /**
@@ -63,12 +62,11 @@ public class ReviewService {
      * @param reviewId 조회할 리뷰의 ID
      * @return 해당 리뷰의 상세 정보를 담은 DTO
      */
-    @Transactional(readOnly = true)
     public ReviewResponseDto getReview(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
 
-        return ReviewResponseDto.of(review);
+        return ReviewResponseDto.from(review);
     }
 
     /**
@@ -88,12 +86,8 @@ public class ReviewService {
             throw new UnauthorizedReviewAccessException("리뷰 작성자만 수정할 수 있습니다.");
         }
 
-        if (review.getContent().equals(reviewRequestDto.getContent())) {
-            return ReviewResponseDto.of(review);
-        }
-
         review.updateReview(reviewRequestDto.getContent());
-        return ReviewResponseDto.of(review);
+        return ReviewResponseDto.from(review);
     }
 
     /**
@@ -102,7 +96,6 @@ public class ReviewService {
      * @param reviewId 삭제할 리뷰의 ID
      * @param member   삭제 요청을 보낸 사용자
      */
-    @Transactional
     public void deleteReview(Long reviewId, Member member) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));

--- a/src/test/java/com/team1/epilogue/review/ReviewServiceTest.java
+++ b/src/test/java/com/team1/epilogue/review/ReviewServiceTest.java
@@ -72,7 +72,8 @@ public class ReviewServiceTest {
         // given
         ReviewRequestDto requestDto = new ReviewRequestDto("정말 좋은 책입니다.");
         when(bookRepository.findById(testBook.getId())).thenReturn(Optional.of(testBook));
-        when(reviewRepository.save(any(Review.class))).thenReturn(testReview);
+        when(reviewRepository.save(argThat(review -> review.getContent().equals("정말 좋은 책입니다."))))
+                .thenReturn(testReview);
 
         // when
         ReviewResponseDto response = reviewService.createReview(testBook.getId(), requestDto, testMember);


### PR DESCRIPTION
## **변경사항**

### **⚙ `of()` -> `from()`으로 변수명 수정**
- `ReviewResponseDto.of()`를 `ReviewResponseDto.from()`으로 수정하였습니다

### **⚙ 필요 없는 트랜잭션 삭제**

### **⚙ 필요 없는 검증 삭제**

- ReviewService의 updateReveiw메서드에서 `review.getContent().equals(reviewRequestDto.getContent())` 불필요한 검증 삭제
- 변경 이유: 내용이 변경되지 않았더라도 수정 요청이 들어온 경우, 변경 여부를 따지지 않고 바로 수정 작업을 진행하기 위해 검증을 삭제했습니다

### **⚙ test 코드 `any()` -> `argThat()`으로 수정**

- **test 코드 `any()` -> `argThat()`으로 수정**: `any()` 매처를 `argThat()`으로 수정하여 더 정확한 검증을 할 수 있도록 하였습니다


