### PR TITLE
feat : mypage 내부 "내 댓글 보기" 기능 추가

### DIFF
--- a/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
@@ -1,10 +1,16 @@
 package com.team1.epilogue.comment.repository;
 
+import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.comment.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment,Long> {
+  @Query("SELECT c FROM Comment c JOIN FETCH c.review r JOIN FETCH r.book WHERE c.member = :member")
+  Page<Comment> findAllByMemberId(Pageable page, Member member);
 
 }

--- a/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
+++ b/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
@@ -1,0 +1,32 @@
+package com.team1.epilogue.mypage.controller;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.mypage.dto.MyPageCommentsResponse;
+import com.team1.epilogue.mypage.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MyPageController {
+
+  private final MyPageService myPageService;
+
+  /**
+   * 마이 페이지 내부 "내 댓글 보기" 기능을 위한 메서드
+   * @param authentication 인증된 사용자 정보를 담은 Authentication 객체
+   * @param page 조회할 페이지 번호
+   */
+  @GetMapping()
+  public ResponseEntity<MyPageCommentsResponse> getMyComments(Authentication authentication,
+      @RequestParam int page) {
+    Member member = (Member) authentication.getPrincipal();
+    MyPageCommentsResponse myComments = myPageService.getMyComments(member, page);
+    return ResponseEntity.ok(myComments);
+  }
+
+}

--- a/src/main/java/com/team1/epilogue/mypage/dto/MyPageCommentsDetailResponse.java
+++ b/src/main/java/com/team1/epilogue/mypage/dto/MyPageCommentsDetailResponse.java
@@ -1,0 +1,18 @@
+package com.team1.epilogue.mypage.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MyPageCommentsDetailResponse {
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm:ss")
+  private LocalDateTime postDateTime;
+  private String bookTitle;
+  private String content;
+
+}

--- a/src/main/java/com/team1/epilogue/mypage/dto/MyPageCommentsResponse.java
+++ b/src/main/java/com/team1/epilogue/mypage/dto/MyPageCommentsResponse.java
@@ -1,0 +1,15 @@
+package com.team1.epilogue.mypage.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class MyPageCommentsResponse {
+  private int totalPage;
+  private int page;
+  private List<MyPageCommentsDetailResponse> comments;
+}

--- a/src/main/java/com/team1/epilogue/mypage/service/MyPageService.java
+++ b/src/main/java/com/team1/epilogue/mypage/service/MyPageService.java
@@ -1,0 +1,43 @@
+package com.team1.epilogue.mypage.service;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.comment.entity.Comment;
+import com.team1.epilogue.comment.repository.CommentRepository;
+import com.team1.epilogue.mypage.dto.MyPageCommentsDetailResponse;
+import com.team1.epilogue.mypage.dto.MyPageCommentsResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+  private final CommentRepository commentRepository;
+
+  public MyPageCommentsResponse getMyComments(Member member, int page) {
+    PageRequest pageRequest = PageRequest.of(page - 1, 20);
+
+    Page<Comment> result = commentRepository.findAllByMemberId(pageRequest, member);
+
+    List<MyPageCommentsDetailResponse> list = new ArrayList<>();
+
+    // 가져온 Page 객체에서 프론트로 줄 데이터 가공
+    result.getContent().stream().forEach( data ->
+        list.add(MyPageCommentsDetailResponse.builder() // 댓글 Detail 을 list 에 담아준다.
+            .postDateTime(data.getCreatedAt()) // 생성일
+            .bookTitle(data.getReview().getBook().getTitle()) // 책제목
+            .content(data.getContent()) // 댓글 내용
+            .build()) // build 해서 List<MyPageCommentsDetailResponse> 에 add
+    );
+
+    return MyPageCommentsResponse.builder()
+        .totalPage(result.getTotalPages()) // 총 페이지 번호
+        .page(page) // 현재 페이지 번호
+        .comments(list) // JSON 내부 배열로 반환
+        .build();
+  }
+}

--- a/src/test/java/com/team1/epilogue/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/team1/epilogue/mypage/service/MyPageServiceTest.java
@@ -1,0 +1,91 @@
+package com.team1.epilogue.mypage.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.book.entity.Book;
+import com.team1.epilogue.comment.entity.Comment;
+import com.team1.epilogue.comment.repository.CommentRepository;
+import com.team1.epilogue.mypage.dto.MyPageCommentsResponse;
+import com.team1.epilogue.review.entity.Review;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class MyPageServiceTest {
+
+  @Mock
+  private CommentRepository commentRepository;
+
+  @InjectMocks
+  private MyPageService myPageService;
+
+  private Member testMember;
+  private Book testBook;
+  private Review testReview;
+
+  @BeforeEach
+  void setUp() {
+    testMember = Member.builder()
+        .id(1L)
+        .loginId("test")
+        .nickname("테스트유저")
+        .build();
+
+    testBook = Book.builder()
+        .id("123456789")
+        .title("테스트책")
+        .build();
+
+    testReview = Review.builder()
+        .id(1L)
+        .member(testMember)
+        .book(testBook)
+        .content("테스트 리뷰내용 입니다.")
+        .build();
+  }
+
+  @Test
+  @DisplayName("내 댓글보기 기능 테스트")
+  void getMyComments() {
+    //given
+    // 테스트용 댓글 10개 추가
+    List<Comment> commentList = new ArrayList<>();
+    for (int i = 1; i <= 10; i++) {
+      commentList.add(
+          Comment.builder()
+              .id((long)i)
+              .member(testMember)
+              .review(testReview)
+              .content(i + "번째 테스트댓글")
+              .build()
+      );
+    }
+
+    // 테스트용 Page 객체 생성
+    PageRequest pageRequest = PageRequest.of(0, 20);
+    Page<Comment> page = new PageImpl<>(commentList, PageRequest.of(0, 20), commentList.size());
+
+    // commentRepository.findAllByMemberId() 를 호출할때 위에서 생성한 page 객체 return
+    when(commentRepository.findAllByMemberId(pageRequest, testMember)).thenReturn(page);
+
+    //when
+    MyPageCommentsResponse result = myPageService.getMyComments(testMember, 1);
+
+    //then
+    assertEquals(10, result.getComments().size());
+    assertEquals(1, result.getTotalPage());
+    assertEquals("10번째 테스트댓글",result.getComments().get(9).getContent());
+  }
+}


### PR DESCRIPTION
- **변경사항**
    - MyPage 에서 사용하는 기능들 중 한가지인 "내 댓글 보기" 기능 API 입니다.
    - 댓글 목록을 불러올때 N+1 문제가 발생 할 수 있습니다.
```
@Entity
@Getter
@Builder(toBuilder = true)
@NoArgsConstructor
@AllArgsConstructor
public class Comment extends BaseEntity {

  @Id
  @GeneratedValue(strategy = GenerationType.IDENTITY)
  private Long id;

  private String content;

  @ManyToOne
  private Member member;

  @ManyToOne
  private Review review;

  private String color; // 댓글 색
}
```
Comment -> Review -> Book 을 가져올때 N+1 이 발생할 수 있어, 아래 코드와 같이 작업하였습니다.
```
  @Query("SELECT c FROM Comment c JOIN FETCH c.review r JOIN FETCH r.book WHERE c.member = :member")
  Page<Comment> findAllByMemberId(Pageable page, Member member);
```
Fetch Join 을 이용하여 Comment Entity 를 가져올때 연관되어있는 Review 와 Book Entity 를 한번에 가져오게끔 하였습니다.

- **리뷰 요청 사항**
    - MyPage 내부 "내 댓글 보기" 기능에 대한 코드리뷰
    - MyPage 내부 "내 댓글 보기" 기능에 대한 테스트 코드리뷰

- **관련된 이슈**
    - #83 
    - 83 번 이슈 내부에 입력예시 , 출력예시 적어놓았습니다.
