### PR TITLE
refactor: 와일드카드 타입 제거 및 모호한 HashMap 응답 구조를 통일된 ApiResponse DTO로 개선

### DIFF
--- a/src/main/java/com/team1/epilogue/auth/controller/AuthController.java
+++ b/src/main/java/com/team1/epilogue/auth/controller/AuthController.java
@@ -1,9 +1,21 @@
 package com.team1.epilogue.auth.controller;
 
-import com.team1.epilogue.auth.dto.*;
+import com.team1.epilogue.auth.dto.ApiResponse;
+import com.team1.epilogue.auth.dto.ErrorResponse;
+import com.team1.epilogue.auth.dto.GeneralLoginRequest;
+import com.team1.epilogue.auth.dto.GoogleUserInfo;
+import com.team1.epilogue.auth.dto.KakaoUserInfo;
+import com.team1.epilogue.auth.dto.LoginResponse;
+import com.team1.epilogue.auth.dto.SuccessResponse;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
-import com.team1.epilogue.auth.service.*;
+import com.team1.epilogue.auth.service.AuthService;
+import com.team1.epilogue.auth.service.GoogleAuthService;
+import com.team1.epilogue.auth.service.KakaoAuthService;
+import com.team1.epilogue.auth.service.GoogleWithdrawalService;
+import com.team1.epilogue.auth.service.KakaoWithdrawalService;
+import com.team1.epilogue.auth.service.LogoutService;
+import com.team1.epilogue.auth.service.MemberWithdrawalService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -13,16 +25,9 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.Map;
-
-/**
- * [클래스 레벨]
- * 인증 및 로그인 관련 HTTP 요청을 처리하는 컨트롤러
- */
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/members")
-@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
@@ -32,173 +37,104 @@ public class AuthController {
     private final GoogleWithdrawalService googleWithdrawalService;
     private final KakaoWithdrawalService kakaoWithdrawalService;
     private final LogoutService logoutService;
-    //private final LogoutService logoutService;
 
-    /**
-     * [메서드 레벨]
-     * 일반 로그인 API
-     *
-     * @param request 일반 로그인 요청 데이터 (ID, 비밀번호 포함)
-     * @return LoginResponse - JWT 토큰 및 사용자 정보 반환
-     * @throws BadCredentialsException 아이디 또는 비밀번호가 올바르지 않을 경우 예외 발생
-     */
+
     @PostMapping(value = "/login", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> login(@RequestBody GeneralLoginRequest request) {
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@RequestBody GeneralLoginRequest request) {
         try {
             LoginResponse response = authService.login(request);
-            return ResponseEntity.ok(response);
+            ApiResponse<LoginResponse> apiResponse = new ApiResponse<>(true, response, null);
+            return ResponseEntity.ok(apiResponse);
         } catch (BadCredentialsException ex) {
-            Map<String, String> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+            ApiResponse<LoginResponse> errorResponse = new ApiResponse<>(false, null, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
         }
     }
 
-//    /**
-//     * [메서드 레벨]
-//     * 소셜 로그인 API (Google, Kakao 등)
-//     *
-//     * @param request 소셜 로그인 요청 데이터 (provider, accessToken 포함)
-//     * @return LoginResponse - JWT 토큰 및 사용자 정보 반환
-//     * @throws IllegalArgumentException 지원되지 않는 소셜 로그인 제공자가 입력된 경우 예외 발생
-//     */
-//    @PostMapping(value = "/login/social", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-//    public ResponseEntity<?> socialLogin(@RequestBody SocialLoginRequest request) {
-//        try {
-//            LoginResponse response = authService.socialLogin(request);
-//            return ResponseEntity.ok(response);
-//        } catch (IllegalArgumentException ex) {
-//            Map<String, String> error = new HashMap<>();
-//            error.put("error", ex.getMessage());
-//            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
-//        }
-//    }
-
-    /**
-     * [메서드 레벨]
-     * 카카오 로그인 콜백 엔드포인트
-     * 카카오 인증 코드(code)를 받아 사용자 정보를 조회하고, 로그인 처리 후 JWT 토큰을 반환
-     *
-     * @param code 카카오에서 제공한 인증 코드
-     * @return 로그인 응답 (JWT 토큰 및 사용자 정보)
-     */
     @GetMapping("/auth/kakao/callback")
-    public ResponseEntity<?> kakaoCallback(@RequestParam("code") String code) {
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoCallback(@RequestParam("code") String code) {
         try {
+            // Note: If needed, change GoogleUserInfo to KakaoUserInfo accordingly.
             KakaoUserInfo kakaoUserInfo = kakaoAuthService.getKakaoUserInfo(code);
             LoginResponse response = authService.socialLoginKakao(kakaoUserInfo);
-            return ResponseEntity.ok(response);
+            ApiResponse<LoginResponse> apiResponse = new ApiResponse<>(true, response, null);
+            return ResponseEntity.ok(apiResponse);
         } catch (Exception ex) {
-            Map<String, String> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            ApiResponse<LoginResponse> errorResponse = new ApiResponse<>(false, null, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
     }
-    /**
-     * [메서드 레벨]
-     * 구글 로그인 콜백 엔드포인트
-     * 구글 인증 코드(code)를 받아 사용자 정보를 조회하고, 로그인 처리 후 JWT 토큰을 반환
-     *
-     * @param code 구글에서 제공한 인증 코드
-     * @return 로그인 응답 (JWT 토큰 및 사용자 정보)
-     */
+
     @GetMapping("/auth/google/callback")
-    public ResponseEntity<?> googleCallback(@RequestParam("code") String code) {
+    public ResponseEntity<ApiResponse<LoginResponse>> googleCallback(@RequestParam("code") String code) {
         try {
             GoogleUserInfo googleUserInfo = googleAuthService.getGoogleUserInfo(code);
             LoginResponse response = authService.socialLoginGoogle(googleUserInfo);
-            return ResponseEntity.ok(response);
+            ApiResponse<LoginResponse> apiResponse = new ApiResponse<>(true, response, null);
+            return ResponseEntity.ok(apiResponse);
         } catch (Exception ex) {
-            Map<String, String> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            ApiResponse<LoginResponse> errorResponse = new ApiResponse<>(false, null, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
     }
-    /**
-     * [메서드 레벨]
-     * 일반 로그아웃 엔드포인트
-     * Authorization 헤더에서 JWT 토큰을 추출하여 무효화 처리
-     *
-     * @param request HTTP 요청 객체
-     * @return 로그아웃 성공 메시지
-     */
+
     @PostMapping(value = "/logout", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> logout(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<SuccessResponse>> logout(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("error", "Authorization header missing or invalid"));
+            ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Authorization header missing or invalid");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
         String token = authHeader.substring(7);
         logoutService.invalidate(token);
-        return ResponseEntity.ok(Map.of("message", "로그아웃 성공"));
+        SuccessResponse success = new SuccessResponse("Logout Success");
+        ApiResponse<SuccessResponse> apiResponse = new ApiResponse<>(true, success, null);
+        return ResponseEntity.ok(apiResponse);
     }
 
-    /**
-     * [메서드 레벨]
-     * 소셜 로그아웃 엔드포인트
-     * Authorization 헤더에서 JWT 토큰을 추출하여 무효화 처리
-     *
-     * @param request HTTP 요청 객체
-     * @return 소셜 로그아웃 성공 메시지
-     */
     @PostMapping(value = "/logout/social", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> socialLogout(HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<SuccessResponse>> socialLogout(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("error", "Authorization header missing or invalid"));
+            ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Authorization header missing or invalid");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
         String token = authHeader.substring(7);
         logoutService.invalidate(token);
-        return ResponseEntity.ok(Map.of("message", "소셜 로그아웃 성공"));
+        SuccessResponse success = new SuccessResponse("Social Logout Success");
+        ApiResponse<SuccessResponse> apiResponse = new ApiResponse<>(true, success, null);
+        return ResponseEntity.ok(apiResponse);
     }
 
-    /**
-     * [메서드 레벨]
-     * 소셜 회원 탈퇴 엔드포인트
-     * 카카오/구글 연동 해제 후, 해당 사용자의 계정을 삭제
-     *
-     * @param provider    소셜 로그인 제공자 (kakao, google)
-     * @param accessToken 사용자의 소셜 액세스 토큰
-     * @param authentication 현재 로그인된 사용자 정보
-     * @return 소셜 회원 탈퇴 결과 메시지
-     */
     @DeleteMapping(value = "/social/withdraw", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> withdrawSocialMember(@RequestParam("provider") String provider,
-                                                  @RequestParam("accessToken") String accessToken,
-                                                  Authentication authentication) {
+    public ResponseEntity<ApiResponse<SuccessResponse>> withdrawSocialMember(
+            @RequestParam("provider") String provider,
+            @RequestParam("accessToken") String accessToken,
+            Authentication authentication) {
+
         if (authentication == null || !authentication.isAuthenticated() ||
-            !(authentication.getPrincipal() instanceof CustomMemberDetails)) {
-            Map<String, Object> errorResponse = new HashMap<>();
-            errorResponse.put("status", 401);
-            errorResponse.put("error", "UNAUTHORIZED");
-            errorResponse.put("message", "인증되지 않은 사용자");
+                !(authentication.getPrincipal() instanceof CustomMemberDetails)) {
+            ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized user");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
         }
         try {
             if ("kakao".equalsIgnoreCase(provider)) {
-                // 카카오 서버와 연동 해제 호출
                 kakaoWithdrawalService.unlinkKakaoAccount(accessToken);
             } else if ("google".equalsIgnoreCase(provider)) {
                 googleWithdrawalService.revokeGoogleAccount(accessToken);
             } else {
-                Map<String, String> error = new HashMap<>();
-                error.put("error", "지원되지 않는 소셜 제공자입니다.");
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+                ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Unsupported social provider");
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
             }
-            // DB 회원 삭제: 인증 정보를 통해 현재 회원 ID를 가져와서 탈퇴 처리
-            Member member = (Member) authentication.getPrincipal();
+            CustomMemberDetails userDetails = (CustomMemberDetails) authentication.getPrincipal();
+            Member member = userDetails.getMember();
             memberWithdrawalService.withdrawMember(member.getId());
-            Map<String, String> success = new HashMap<>();
-            success.put("message", "소셜 회원 탈퇴 성공");
-            return ResponseEntity.ok(success);
+            SuccessResponse success = new SuccessResponse("Social member withdrawal success");
+            ApiResponse<SuccessResponse> apiResponse = new ApiResponse<>(true, success, null);
+            return ResponseEntity.ok(apiResponse);
         } catch (Exception ex) {
-            Map<String, String> error = new HashMap<>();
-            error.put("error", ex.getMessage());
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+            ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, ex.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
         }
     }
 }
-
-

--- a/src/main/java/com/team1/epilogue/auth/controller/MemberController.java
+++ b/src/main/java/com/team1/epilogue/auth/controller/MemberController.java
@@ -28,20 +28,20 @@ public class MemberController {
   public ResponseEntity<ApiResponse<MemberResponse>> registerMember(
           @RequestBody @Validated RegisterRequest request) {
     MemberResponse memberResponse = memberService.registerMember(request);
-    ApiResponse<MemberResponse> response = new ApiResponse<>(true, memberResponse, null);
+    ApiResponse<MemberResponse> response = new ApiResponse<>(true, memberResponse, null, "Registration success");
     return ResponseEntity.ok(response);
   }
 
   @DeleteMapping
   public ResponseEntity<ApiResponse<SuccessResponse>> withdrawMember(Authentication authentication) {
     if (authentication == null || !authentication.isAuthenticated()) {
-      ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized user");
+      ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized user", null);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
     Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
     memberWithdrawalService.withdrawMember(memberId);
-    SuccessResponse success = new SuccessResponse("User account deleted successfully ");
-    ApiResponse<SuccessResponse> response = new ApiResponse<>(true, success, null);
+    SuccessResponse success = new SuccessResponse("User account deleted successfully");
+    ApiResponse<SuccessResponse> response = new ApiResponse<>(true, success, null, "Deletion success");
     return ResponseEntity.ok(response);
   }
 
@@ -50,20 +50,16 @@ public class MemberController {
           @RequestBody @Validated UpdateMemberRequest request,
           Authentication authentication) {
     if (authentication == null || !authentication.isAuthenticated()) {
-      ApiResponse<MemberResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized");
+      ApiResponse<MemberResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized", null);
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
-
     Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
     MemberResponse updatedMember = memberService.updateMember(memberId, request);
-
     if (updatedMember == null) {
       return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-              .body(new ApiResponse<>(false, null, "Update failed"));
+              .body(new ApiResponse<>(false, null, "Update failed", null));
     }
-
-    ApiResponse<MemberResponse> response = new ApiResponse<>(true, updatedMember, null);
+    ApiResponse<MemberResponse> response = new ApiResponse<>(true, updatedMember, null, "User information updated successfully");
     return ResponseEntity.ok(response);
   }
-
 }

--- a/src/main/java/com/team1/epilogue/auth/controller/MemberController.java
+++ b/src/main/java/com/team1/epilogue/auth/controller/MemberController.java
@@ -1,7 +1,9 @@
 package com.team1.epilogue.auth.controller;
 
-import com.team1.epilogue.auth.dto.RegisterRequest;
+import com.team1.epilogue.auth.dto.ApiResponse;
 import com.team1.epilogue.auth.dto.MemberResponse;
+import com.team1.epilogue.auth.dto.RegisterRequest;
+import com.team1.epilogue.auth.dto.SuccessResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.auth.service.MemberService;
@@ -14,102 +16,54 @@ import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.Map;
-
-/**
- * [클래스 레벨]
- * 회원 관리 컨트롤러 (일반/소셜원가입, 정보수정, 탈퇴)
- */
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/members")
-@RequiredArgsConstructor
 public class MemberController {
 
   private final MemberService memberService;
   private final MemberWithdrawalService memberWithdrawalService;
 
-  /**
-   * [메서드 레벨]
-   * 회원 가입 API
-   *
-   * @param request 회원 가입 요청 데이터
-   * @return 생성된 회원 정보 반환
-   */
   @PostMapping(value = "/register", consumes = MediaType.APPLICATION_JSON_VALUE)
-  public MemberResponse registerMember(@RequestBody @Validated RegisterRequest request) {
-    return memberService.registerMember(request);
-  }
-
-  /**
-   * [메서드 레벨]
-   * 회원 탈퇴 API
-   *
-   * @param authentication 현재 인증된 사용자 정보
-   * @return 성공 메시지 반환
-   */
-  @DeleteMapping
-  public ResponseEntity<?> withdrawMember(Authentication authentication) {
-
-    if (authentication == null || !authentication.isAuthenticated()) {
-      return createErrorResponse(401, "UNAUTHORIZED", "인증되지 않은 사용자");
-    }
-    Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
-    memberWithdrawalService.withdrawMember(memberId);
-
-    return createSuccessResponse("유저의 계정이 정상적으로 삭제되었습니다.");
-  }
-
-  /**
-   * [메서드 레벨]
-   * 회원 정보 수정 API
-   *
-   * @param request        회원 정보 수정 요청 데이터
-   * @param authentication 현재 인증된 사용자 정보
-   * @return 수정된 회원 정보 반환
-   */
-  @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> updateMember(@RequestBody @Validated UpdateMemberRequest request,
-                                        Authentication authentication) {
-    if (authentication == null || !authentication.isAuthenticated()) {
-      return createErrorResponse(401, "UNAUTHORIZED", "인증 실패");
-    }
-    Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
-    MemberResponse updatedMember = memberService.updateMember(memberId, request);
-
-    Map<String, Object> response = new HashMap<>();
-    response.put("메시지", "유저 정보 수정 완료");
-    response.put("유저", updatedMember);
+  public ResponseEntity<ApiResponse<MemberResponse>> registerMember(
+          @RequestBody @Validated RegisterRequest request) {
+    MemberResponse memberResponse = memberService.registerMember(request);
+    ApiResponse<MemberResponse> response = new ApiResponse<>(true, memberResponse, null);
     return ResponseEntity.ok(response);
   }
 
-  /**
-   * [메서드 레벨]
-   * 에러 응답 생성 메서드
-   *
-   * @param status    HTTP 상태 코드
-   * @param errorCode 오류 코드
-   * @param message   오류 메시지
-   * @return 에러 응답 ResponseEntity
-   */
-  private ResponseEntity<Map<String, Object>> createErrorResponse(int status, String errorCode, String message) {
-    Map<String, Object> errorResponse = new HashMap<>();
-    errorResponse.put("상태", status);
-    errorResponse.put("에러코드", errorCode);
-    errorResponse.put("메시지", message);
-    return ResponseEntity.status(HttpStatus.valueOf(status)).body(errorResponse);
+  @DeleteMapping
+  public ResponseEntity<ApiResponse<SuccessResponse>> withdrawMember(Authentication authentication) {
+    if (authentication == null || !authentication.isAuthenticated()) {
+      ApiResponse<SuccessResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized user");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+    Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
+    memberWithdrawalService.withdrawMember(memberId);
+    SuccessResponse success = new SuccessResponse("User account deleted successfully ");
+    ApiResponse<SuccessResponse> response = new ApiResponse<>(true, success, null);
+    return ResponseEntity.ok(response);
   }
 
-  /**
-   * [메서드 레벨]
-   * 성공 응답 생성 메서드
-   *
-   * @param message 성공 메시지
-   * @return 성공 응답 ResponseEntity
-   */
-  private ResponseEntity<Map<String, String>> createSuccessResponse(String message) {
-    Map<String, String> successResponse = new HashMap<>();
-    successResponse.put("메시지", message);
-    return ResponseEntity.ok(successResponse);
+  @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ApiResponse<MemberResponse>> updateMember(
+          @RequestBody @Validated UpdateMemberRequest request,
+          Authentication authentication) {
+    if (authentication == null || !authentication.isAuthenticated()) {
+      ApiResponse<MemberResponse> errorResponse = new ApiResponse<>(false, null, "Unauthorized");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
+    }
+
+    Long memberId = ((CustomMemberDetails) authentication.getPrincipal()).getId();
+    MemberResponse updatedMember = memberService.updateMember(memberId, request);
+
+    if (updatedMember == null) {
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+              .body(new ApiResponse<>(false, null, "Update failed"));
+    }
+
+    ApiResponse<MemberResponse> response = new ApiResponse<>(true, updatedMember, null);
+    return ResponseEntity.ok(response);
   }
+
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/ApiResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.team1.epilogue.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private T data;
+    private String error;
+}

--- a/src/main/java/com/team1/epilogue/auth/dto/ApiResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/ApiResponse.java
@@ -9,4 +9,5 @@ public class ApiResponse<T> {
     private boolean success;
     private T data;
     private String error;
+    private String message;
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/ErrorResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.team1.epilogue.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+    private int status;
+    private String error;
+    private String message;
+}

--- a/src/main/java/com/team1/epilogue/auth/dto/GeneralLoginRequest.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/GeneralLoginRequest.java
@@ -1,12 +1,15 @@
 package com.team1.epilogue.auth.dto;
 
-import lombok.Data;
+import lombok.*;
 
 /**
  * [클래스 레벨]
  * 일반 로그인 요청 데이터를 전달하기 위한 DTO
  */
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class GeneralLoginRequest {
     private String loginId;
     private String password;

--- a/src/main/java/com/team1/epilogue/auth/dto/GoogleUserInfo.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/GoogleUserInfo.java
@@ -2,44 +2,24 @@ package com.team1.epilogue.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-/**
- * [클래스 레벨]
- * GoogleUserInfo 클래스는 Google OAuth2 로그인 시 받아오는 사용자 정보를 담는 DTO
- */
-@Data
+
+@Getter
+@Setter
+@NoArgsConstructor
 public class GoogleUserInfo {
-    /**
-     * [필드 레벨]
-     * sub: Google의 고유 사용자 ID
-     */
+
     private String sub;
 
-    /**
-     * [필드 레벨]
-     * email: 사용자 이메일
-     */
     private String email;
 
-    /**
-     * [필드 레벨]
-     * emailVerified: 이메일 인증 여부
-     */
     @JsonProperty("email_verified")
     private String emailVerified;
-
-    /**
-     * [필드 레벨]
-     * name: 사용자 이름
-     */
     private String name;
-
-    /**
-     * [필드 레벨]
-     * picture: 사용자 프로필 사진 URL
-     */
     private String picture;
-
     private String given_name;
     private String family_name;
     private String locale;

--- a/src/main/java/com/team1/epilogue/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/KakaoUserInfo.java
@@ -1,60 +1,33 @@
 package com.team1.epilogue.auth.dto;
 
-import lombok.Data;
+import lombok.*;
 
-/**
- * [클래스 레벨]
- * KakaoUserInfo 클래스는 Kakao OAuth2 로그인 시 받아오는 사용자 정보를 담는 DTO
- */
-@Data
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class KakaoUserInfo {
-    /**
-     * [필드 레벨]
-     * id: 카카오의 고유 사용자 ID
-     */
-    private Long id;
 
-    /**
-     * [필드 레벨]
-     * kakao_account: 카카오 계정 정보
-     */
+    private Long id;
     private KakaoAccount kakao_account;
 
-    /**
-     * [클래스 레벨]
-     * KakaoAccount 클래스는 카카오에서 반환하는 계정 정보를 담는 내부 클래스
-     */
-    @Data
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class KakaoAccount {
-        /**
-         * [필드 레벨]
-         * email: 사용자 이메일
-         */
         private String email;
-
-        /**
-         * [필드 레벨]
-         * profile: 사용자 프로필 정보
-         */
         private KakaoProfile profile;
     }
 
-    /**
-     * [클래스 레벨]
-     * KakaoProfile 클래스는 카카오에서 반환하는 프로필 정보를 담는 내부 클래스
-     */
-    @Data
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class KakaoProfile {
-        /**
-         * [필드 레벨]
-         * nickname: 사용자 닉네임
-         */
-        private String nickname;
 
-        /**
-         * [필드 레벨]
-         * profileImageUrl: 사용자 프로필 사진 URL
-         */
+        private String nickname;
         private String profileImageUrl;
     }
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/LoginResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/LoginResponse.java
@@ -1,62 +1,28 @@
 package com.team1.epilogue.auth.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-/**
- * [클래스 레벨]
- * LoginResponse 클래스는 로그인 성공 시 반환되는 응답 데이터를 담는 DTO
- */
-@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Builder
 public class LoginResponse {
-    /**
-     * [필드 레벨]
-     * message: 로그인 결과 메시지
-     */
+
     private String message;
-
-    /**
-     * [필드 레벨]
-     * accessToken: 발급된 JWT 액세스 토큰
-     */
     private String accessToken;
-
-    /**
-     * [필드 레벨]
-     * user: 로그인한 사용자 정보
-     */
     private UserInfo user;
 
-    /**
-     * [클래스 레벨]
-     * UserInfo 클래스는 로그인한 사용자의 정보를 담는 내부 DTO
-     */
-    @Data
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Builder
     public static class UserInfo {
-        /**
-         * [필드 레벨]
-         * id: 사용자 고유 식별자
-         */
         private String id;
-
-        /**
-         * [필드 레벨]
-         * userId: 사용자 로그인 ID
-         */
         private String userId;
-
-        /**
-         * [필드 레벨]
-         * name: 사용자 이름
-         */
         private String name;
-
-        /**
-         * [필드 레벨]
-         * profileImg: 사용자 프로필 이미지 URL
-         */
         private String profileImg;
     }
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/MemberResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/MemberResponse.java
@@ -1,13 +1,15 @@
 package com.team1.epilogue.auth.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
-/**
- * [클래스 레벨]
- * MemberResponse 클래스는 회원 등록 후 반환되는 응답 데이터를 담는 DTO
- */
-@Data
+
+@Getter
 @Builder
 public class MemberResponse {
     private String id;

--- a/src/main/java/com/team1/epilogue/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/RegisterRequest.java
@@ -16,65 +16,32 @@ import jakarta.validation.constraints.Size;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Data
 public class RegisterRequest {
 
-    /**
-     * [필드 레벨]
-     * loginId: 사용자 로그인 ID, 필수 입력
-     */
     @NotBlank(message = "loginId는 필수입니다.")
     private String loginId;
 
-    /**
-     * [필드 레벨]
-     * password: 사용자 비밀번호, 필수 입력, 최소 6자 이상
-     */
     @NotBlank(message = "password는 필수입니다.")
     @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
     private String password;
 
-    /**
-     * [필드 레벨]
-     * nickname: 사용자 닉네임, 필수 입력
-     */
     @NotBlank(message = "nickname은 필수입니다.")
     private String nickname;
 
-    /**
-     * [필드 레벨]
-     * name: 사용자 이름, 필수 입력
-     */
     @NotBlank(message = "name은 필수입니다.")
     private String name;
 
-    /**
-     * [필드 레벨]
-     * birthDate: 사용자 생년월일, 필수 입력, 형식은 "YYYY-MM-DD"이어야 함
-     */
     @NotBlank(message = "birthDate는 필수입니다.")
     @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}", message = "생년월일 형식은 YYYY-MM-DD 여야 합니다.")
     private String birthDate;
 
-    /**
-     * [필드 레벨]
-     * email: 사용자 이메일, 필수 입력, 유효한 이메일 형식
-     */
     @NotBlank(message = "email은 필수입니다.")
     @Email(message = "유효한 이메일 형식을 입력하세요.")
     private String email;
 
-    /**
-     * [필드 레벨]
-     * phone: 사용자 전화번호, 필수 입력, 형식 조건 적용
-     */
     @NotBlank(message = "phone은 필수입니다.")
     @Pattern(regexp = "\\d{2,3}-\\d{3,4}-\\d{4}", message = "전화번호 형식에 맞지 않습니다.")
     private String phone;
 
-    /**
-     * [필드 레벨]
-     * profileUrl: 사용자 프로필 사진 URL, 선택 입력
-     */
     private String profileUrl;
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/SocialLoginRequest.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/SocialLoginRequest.java
@@ -1,12 +1,11 @@
 package com.team1.epilogue.auth.dto;
 
-import lombok.Data;
+import lombok.*;
 
-/**
- * [클래스 레벨]
- * 소셜 로그인(구글, 카카오) 요청 데이터를 전달하기 위한 DTO
- */
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class SocialLoginRequest {
     private String provider;
     private String accessToken;

--- a/src/main/java/com/team1/epilogue/auth/dto/SuccessResponse.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/SuccessResponse.java
@@ -1,0 +1,12 @@
+package com.team1.epilogue.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SuccessResponse {
+    private String message;
+}

--- a/src/main/java/com/team1/epilogue/auth/dto/UpdateMemberRequest.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/UpdateMemberRequest.java
@@ -5,11 +5,6 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
-/**
- * [클래스 레벨]
- * UpdateMemberRequest 클래스는 회원 정보 수정 요청을 담는 DTO
- */
-@Data
 @Getter
 @Setter
 @NoArgsConstructor
@@ -27,9 +22,5 @@ public class UpdateMemberRequest {
     @Pattern(regexp = "\\d{2,3}-\\d{3,4}-\\d{4}", message = "전화번호 형식에 맞지 않습니다.")
     private String phone;
 
-    /**
-     * [필드 레벨]
-     * profilePhoto: 사용자 프로필 사진 URL (선택적 입력)
-     */
     private String profilePhoto;
 }

--- a/src/main/java/com/team1/epilogue/auth/dto/UserDto.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/UserDto.java
@@ -1,15 +1,12 @@
 package com.team1.epilogue.auth.dto;
 
-import lombok.Data;
-import lombok.Builder;
+import lombok.*;
 
 
-/**
- * [클래스 레벨]
- * 사용자 정보를 클라이언트에 전달하기 위한 DTO
- */
-@Data
+@Getter
 @Builder
+@ToString
+@EqualsAndHashCode
 public class UserDto {
     private Long id;
     private String userId;

--- a/src/main/java/com/team1/epilogue/auth/dto/UserDto.java
+++ b/src/main/java/com/team1/epilogue/auth/dto/UserDto.java
@@ -12,7 +12,6 @@ import lombok.Builder;
 @Builder
 public class UserDto {
     private Long id;
-
     private String userId;
     private String name;
     private String profileImg;

--- a/src/main/java/com/team1/epilogue/auth/entity/Member.java
+++ b/src/main/java/com/team1/epilogue/auth/entity/Member.java
@@ -6,16 +6,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 import lombok.Setter;
+import java.time.LocalDate;
 
-/**
- * [클래스 레벨]
- * Member 엔티티는 회원 정보를 데이터베이스에 저장하기 위한 JPA 엔티티
- * 새로운 DB 스키마에 따라 필드명이 변경되었으며,
- * 로그인 ID, 닉네임, 이름, 생년월일, 이메일, 전화번호, 프로필 URL, 포인트, 소셜 정보, 가입일 등의 컬럼을 포함
- */
 @Entity
 @Table(name = "member")
 @NoArgsConstructor
@@ -25,82 +18,37 @@ import lombok.Setter;
 @Setter
 public class Member extends BaseEntity {
 
-    /**
-     * [필드 레벨]
-     * id: 회원의 고유 식별자로, 데이터베이스에서 자동 생성
-     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /**
-     * [필드 레벨]
-     * loginId: 회원의 로그인 ID로, 고유하며 필수 값
-     */
     @Column(name = "login_id", nullable = false, unique = true)
     private String loginId;
 
-    /**
-     * [필드 레벨]
-     * password: 회원의 비밀번호를 암호화하여 저장
-     */
     @Column(nullable = false)
     private String password;
 
-    /**
-     * [필드 레벨]
-     * nickname: 회원의 닉네임이며, 필수 값
-     */
     @Column(nullable = false)
     private String nickname;
 
-    /**
-     * [필드 레벨]
-     * name: 회원의 이름, 필수 값
-     */
     @Column(nullable = false)
     private String name;
 
-    /**
-     * [필드 레벨]
-     * birthDate: 회원의 생년월일. ISO 형식(LocalDate)으로 저장
-     */
     @Column(name = "birth_date", nullable = false)
     private LocalDate birthDate;
 
-    /**
-     * [필드 레벨]
-     * email: 회원의 이메일 주소로, 고유하며 필수 값
-     */
     @Column(nullable = false, unique = true)
     private String email;
 
-    /**
-     * [필드 레벨]
-     * phone: 회원의 전화번호, 필수 값
-     */
     @Column(nullable = false)
     private String phone;
 
-    /**
-     * [필드 레벨]
-     * profileUrl: 회원의 프로필 사진 S3 URL.
-     */
     @Column(name = "profile_url")
     private String profileUrl;
 
-    /**
-     * [필드 레벨]
-     * point: 회원의 포인트, 기본값 0
-     */
     @Column(nullable = false)
     private int point;
 
-    /**
-     * [필드 레벨]
-     * social: 소셜 로그인 정보(예: KAKAO, GOOGLE 등), 선택 값
-     */
     @Column
     private String social;
-
 }

--- a/src/main/java/com/team1/epilogue/auth/exception/EmailAlreadyExistException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/EmailAlreadyExistException.java
@@ -1,31 +1,15 @@
 package com.team1.epilogue.auth.exception;
 
-/**
- * [클래스 레벨]
- * EmailAlreadyExistException은 이미 사용 중인 이메일로 회원가입 시 발생하는 예외
- * 이 예외는 RuntimeException을 상속받으며, 기본 메시지와 HTTP 상태 코드를 포함
- */
+
 public class EmailAlreadyExistException extends RuntimeException {
 
-    // [필드 레벨]
-    // HTTP 상태 코드를 저장하는 필드입니다.
     private final int status;
 
-    /**
-     * [생성자 레벨]
-     * 기본 생성자는 "이미 등록된 이메일입니다."라는 메시지와 HTTP 상태 코드 400을 설정
-     */
     public EmailAlreadyExistException() {
         super("이미 등록된 이메일입니다.");
         this.status = 400;
     }
 
-    /**
-     * [메서드 레벨]
-     * getStatus 메서드는 예외에 설정된 HTTP 상태 코드를 반환
-     *
-     * @return HTTP 상태 코드
-     */
     public int getStatus() {
         return status;
     }

--- a/src/main/java/com/team1/epilogue/auth/exception/IdAlreadyExistException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/IdAlreadyExistException.java
@@ -1,9 +1,6 @@
 package com.team1.epilogue.auth.exception;
 
-/**
- * [클래스 레벨]
- * IdAlreadyExistException은 이미 사용 중인 로그인 ID로 회원가입 시 발생하는 예외
- */
+
 public class IdAlreadyExistException extends RuntimeException {
     public IdAlreadyExistException() {
         super("이미 등록된 사용자 ID입니다.");

--- a/src/main/java/com/team1/epilogue/auth/exception/InvalidEmailFormatException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/InvalidEmailFormatException.java
@@ -1,9 +1,6 @@
 package com.team1.epilogue.auth.exception;
 
-/**
- * [클래스 레벨]
- * EmailNotValidException은 유효하지 않은 이메일 형식이 입력될 때 발생하는 런타임 예외
- */
+
 public class InvalidEmailFormatException extends RuntimeException {
     public InvalidEmailFormatException() {
         super("유효하지 않은 이메일 형식입니다.");

--- a/src/main/java/com/team1/epilogue/auth/exception/InvalidPasswordException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/InvalidPasswordException.java
@@ -3,10 +3,7 @@ package com.team1.epilogue.auth.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-/**
- * [클래스 레벨]
- * 비밀번호가 6자리 미만일 때 발생하는 예외
- */
+
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class InvalidPasswordException extends RuntimeException {
     public InvalidPasswordException() {super("비밀번호는 최소 6자리 이상이어야 합니다.");}

--- a/src/main/java/com/team1/epilogue/auth/exception/InvalidPhoneFormatException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/InvalidPhoneFormatException.java
@@ -1,9 +1,6 @@
 package com.team1.epilogue.auth.exception;
 
-/**
- * [클래스 레벨]
- * 회원가입 관련 예외를 처리하기 위한 커스텀 예외 클래스
- */
+
 public class InvalidPhoneFormatException extends RuntimeException {
     public InvalidPhoneFormatException() {super("전화번호 형식에 맞지 않습니다.");}
 }

--- a/src/main/java/com/team1/epilogue/auth/exception/MemberNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/MemberNotFoundException.java
@@ -1,9 +1,5 @@
 package com.team1.epilogue.auth.exception;
 
-/**
- * [클래스 레벨]
- * MemberNotFoundException은 회원 정보를 찾을 수 없을 때 발생하는 예외
- */
 public class MemberNotFoundException extends RuntimeException {
     public MemberNotFoundException() {
         super("회원 정보를 찾을 수 없습니다.");

--- a/src/main/java/com/team1/epilogue/auth/exception/MissingRequiredFieldException.java
+++ b/src/main/java/com/team1/epilogue/auth/exception/MissingRequiredFieldException.java
@@ -3,10 +3,6 @@ package com.team1.epilogue.auth.exception;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-/**
- * [클래스 레벨]
- * 필수 입력 필드 누락 예외
- */
 @ResponseStatus(HttpStatus.BAD_REQUEST)
 public class MissingRequiredFieldException extends RuntimeException {
     public MissingRequiredFieldException() {super("필수입력 항목입니다.");}

--- a/src/main/java/com/team1/epilogue/auth/security/CustomMemberDetails.java
+++ b/src/main/java/com/team1/epilogue/auth/security/CustomMemberDetails.java
@@ -1,19 +1,17 @@
 package com.team1.epilogue.auth.security;
 
 import com.team1.epilogue.auth.entity.Member;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
 import java.util.Collections;
 
-/**
- * [클래스 레벨]
- * UserDetails 인터페이스를 구현한 커스텀 사용자 정보 클래스.
- * 인증 및 인가에 필요한 사용자 정보를 제공.
- */
+@Getter
 public class CustomMemberDetails implements UserDetails {
 
+    private final Member member;
     private final Long id;
     private final String username;
     private final String password;
@@ -21,9 +19,10 @@ public class CustomMemberDetails implements UserDetails {
     private final String name;
     private final String profileImg;
 
-    public CustomMemberDetails(Long id, String username, String password,
+    public CustomMemberDetails(Member member, Long id, String username, String password,
                                Collection<? extends GrantedAuthority> authorities,
                                String name, String profileImg) {
+        this.member = member;
         this.id = id;
         this.username = username;
         this.password = password;
@@ -32,62 +31,37 @@ public class CustomMemberDetails implements UserDetails {
         this.profileImg = profileImg;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getProfileImg() {
-        return profileImg;
-    }
-
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;
     }
-
     @Override
     public String getPassword() {
         return password;
     }
-
     @Override
     public String getUsername() {
         return username;
     }
-
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
-
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
-
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
-
     @Override
     public boolean isEnabled() {
         return true;
     }
-
-    /**
-     * [메서드 레벨]
-     * Member 엔티티를 CustomMemberDetails 객체로 변환하는 정적 팩토리 메서드.
-     *
-     * @param member Member 엔티티
-     * @return CustomMemberDetails 객체
-     */
     public static CustomMemberDetails fromMember(Member member) {
         return new CustomMemberDetails(
+                member,
                 member.getId(),
                 member.getLoginId(),
                 member.getPassword(),

--- a/src/main/java/com/team1/epilogue/auth/security/CustomMemberDetails.java
+++ b/src/main/java/com/team1/epilogue/auth/security/CustomMemberDetails.java
@@ -3,6 +3,7 @@ package com.team1.epilogue.auth.security;
 import com.team1.epilogue.auth.entity.Member;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -15,12 +16,12 @@ public class CustomMemberDetails implements UserDetails {
     private final Long id;
     private final String username;
     private final String password;
-    private final Collection<? extends GrantedAuthority> authorities;
+    private final Collection<GrantedAuthority> authorities;
     private final String name;
     private final String profileImg;
 
     public CustomMemberDetails(Member member, Long id, String username, String password,
-                               Collection<? extends GrantedAuthority> authorities,
+                               Collection<GrantedAuthority> authorities,
                                String name, String profileImg) {
         this.member = member;
         this.id = id;
@@ -32,40 +33,47 @@ public class CustomMemberDetails implements UserDetails {
     }
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
+    public Collection<GrantedAuthority> getAuthorities() {
         return authorities;
     }
+
     @Override
     public String getPassword() {
         return password;
     }
+
     @Override
     public String getUsername() {
         return username;
     }
+
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
+
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
+
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
+
     @Override
     public boolean isEnabled() {
         return true;
     }
+
     public static CustomMemberDetails fromMember(Member member) {
         return new CustomMemberDetails(
                 member,
                 member.getId(),
                 member.getLoginId(),
                 member.getPassword(),
-                Collections.singleton(() -> "ROLE_USER"),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
                 member.getName(),
                 member.getProfileUrl()
         );

--- a/src/main/java/com/team1/epilogue/auth/service/AuthService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/AuthService.java
@@ -3,31 +3,12 @@ package com.team1.epilogue.auth.service;
 import com.team1.epilogue.auth.dto.*;
 import org.springframework.stereotype.Service;
 
-/**
- * [클래스 레벨]
- * 로그인 관련 비즈니스 로직을 정의하는 서비스 인터페이스 (동기 방식)
- */
+
 @Service
 public interface AuthService {
-    /**
-     * [메서드 레벨]
-     * 일반 로그인 기능을 수행
-     *
-     * @param request 일반 로그인 요청 데이터
-     * @return LoginResponse - 로그인 결과 응답
-     */
+
     LoginResponse login(GeneralLoginRequest request);
-
-    /**
-     * [메서드 레벨]
-     * 소셜 로그인 기능(구글, 카카오 등)을 수행
-     *
-     * @param request 소셜 로그인 요청 데이터
-     * @return LoginResponse - 로그인 결과 응답
-     */
     LoginResponse socialLogin(SocialLoginRequest request);
-
-    // 카카오 구글 콜백용 소셜 로그인 메서드
     LoginResponse socialLoginKakao(KakaoUserInfo kakaoUserInfo);
     LoginResponse socialLoginGoogle(GoogleUserInfo googleUserInfo);
 }

--- a/src/main/java/com/team1/epilogue/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/team1/epilogue/auth/service/AuthServiceImpl.java
@@ -1,6 +1,10 @@
 package com.team1.epilogue.auth.service;
 
-import com.team1.epilogue.auth.dto.*;
+import com.team1.epilogue.auth.dto.GoogleUserInfo;
+import com.team1.epilogue.auth.dto.GeneralLoginRequest;
+import com.team1.epilogue.auth.dto.KakaoUserInfo;
+import com.team1.epilogue.auth.dto.LoginResponse;
+import com.team1.epilogue.auth.dto.SocialLoginRequest;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.repository.MemberRepository;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
@@ -9,55 +13,36 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.*;
 
-/**
- * [클래스 레벨]
- * 인증 관련 비즈니스 로직을 구현한 서비스 클래스
- */
 @Service
 @RequiredArgsConstructor
-public class AuthServiceImpl implements AuthService {
+public class AuthServiceImpl implements com.team1.epilogue.auth.service.AuthService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final GoogleAuthService googleAuthService;
-    private final KakaoAuthService kakaoAuthService;
+    private final com.team1.epilogue.auth.service.GoogleAuthService googleAuthService;
+    private final com.team1.epilogue.auth.service.KakaoAuthService kakaoAuthService;
 
-    /**
-     * [메서드 레벨]
-     * 일반 로그인 처리
-     *
-     * @param request 일반 로그인 요청 데이터
-     * @return 로그인 성공 시 JWT 토큰과 사용자 정보 반환
-     * @throws BadCredentialsException 잘못된 아이디 또는 비밀번호 예외
-     */
+
     @Override
     public LoginResponse login(GeneralLoginRequest request) {
         Member member = memberRepository.findByLoginId(request.getLoginId())
-                .orElseThrow(() -> new BadCredentialsException("아이디 혹은 패스워드가 틀립니다."));
+                .orElseThrow(() -> new BadCredentialsException("Invalid username or password."));
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-            throw new BadCredentialsException("아이디 혹은 패스워드가 틀립니다.");
+            throw new BadCredentialsException("Invalid username or password.");
         }
         CustomMemberDetails userDetails = CustomMemberDetails.fromMember(member);
         String token = jwtTokenProvider.generateToken(String.valueOf(member.getId()));
         return buildLoginResponse(userDetails, token);
     }
 
-    /**
-     * [메서드 레벨]
-     * 소셜 로그인 처리 (Google, Kakao)
-     *
-     * @param request 소셜 로그인 요청 데이터
-     * @return 로그인 성공 시 JWT 토큰과 사용자 정보 반환
-     * @throws IllegalArgumentException 지원되지 않는 소셜 로그인 제공자 예외
-     */
     @Override
     public LoginResponse socialLogin(SocialLoginRequest request) {
         Member member;
         if ("google".equalsIgnoreCase(request.getProvider())) {
             GoogleUserInfo googleUser = googleAuthService.getGoogleUserInfo(request.getAccessToken());
-            // 통일: "google_" 접두사를 붙여 loginId 생성
             String unifiedLoginId = "google_" + googleUser.getSub();
             member = findOrCreateMember(
                     googleUser.getEmail(),
@@ -68,7 +53,6 @@ public class AuthServiceImpl implements AuthService {
             );
         } else if ("kakao".equalsIgnoreCase(request.getProvider())) {
             KakaoUserInfo kakaoUser = kakaoAuthService.getKakaoUserInfo(request.getAccessToken());
-            // 통일: "kakao_" 접두사를 붙여 loginId 생성
             String unifiedLoginId = "kakao_" + kakaoUser.getId();
             member = findOrCreateMember(
                     kakaoUser.getKakao_account().getEmail(),
@@ -78,23 +62,13 @@ public class AuthServiceImpl implements AuthService {
                     "kakao"
             );
         } else {
-            throw new IllegalArgumentException("지원하지 되지않는 소셜 제공자");
+            throw new IllegalArgumentException("Unsupported social provider.");
         }
-
         CustomMemberDetails userDetails = CustomMemberDetails.fromMember(member);
         String token = jwtTokenProvider.generateToken(String.valueOf(member.getId()));
         return buildLoginResponse(userDetails, token);
     }
 
-    /**
-     * [메서드 레벨]
-     * 카카오 소셜 로그인 처리
-     * - 카카오에서 가져온 사용자 정보를 이용하여 회원을 조회하거나 생성
-     * - JWT 토큰을 생성하여 반환
-     *
-     * @param kakaoUserInfo 카카오 사용자 정보 객체
-     * @return 로그인 응답 (JWT 토큰 및 사용자 정보 포함)
-     */
     @Override
     public LoginResponse socialLoginKakao(KakaoUserInfo kakaoUserInfo) {
         Member member = findOrCreateMember(
@@ -109,15 +83,6 @@ public class AuthServiceImpl implements AuthService {
         return buildLoginResponse(userDetails, token);
     }
 
-    /**
-     * [메서드 레벨]
-     * 구글 소셜 로그인 처리
-     * - 구글에서 가져온 사용자 정보를 이용하여 회원을 조회하거나 생성
-     * - JWT 토큰을 생성하여 반환
-     *
-     * @param googleUserInfo 구글 사용자 정보 객체
-     * @return 로그인 응답 (JWT 토큰 및 사용자 정보 포함)
-     */
     @Override
     public LoginResponse socialLoginGoogle(GoogleUserInfo googleUserInfo) {
         String unifiedLoginId = "google_" + googleUserInfo.getSub();
@@ -133,33 +98,26 @@ public class AuthServiceImpl implements AuthService {
         return buildLoginResponse(userDetails, token);
     }
 
-    /**
-     * [메서드 레벨]
-     * 소셜 로그인 사용자의 회원 정보를 찾거나 신규 회원 생성
-     */
     private Member findOrCreateMember(String email, String loginId, String name, String profileUrl, String socialType) {
-        return memberRepository.findByEmail(email).orElseGet(() -> memberRepository.save(
-                Member.builder()
-                        .loginId(loginId)
-                        .password("")
-                        .nickname(name)
-                        .name(name)
-                        .email(email)
-                        .phone("")
-                        .profileUrl(profileUrl)
-                        .point(0)
-                        .social(socialType)
-                        .build()
-        ));
+        return memberRepository.findByEmail(email)
+                .orElseGet(() -> memberRepository.save(
+                        Member.builder()
+                                .loginId(loginId)
+                                .password("") // Not used for social login
+                                .nickname(name)
+                                .name(name)
+                                .email(email)
+                                .phone("")
+                                .profileUrl(profileUrl)
+                                .point(0)
+                                .social(socialType)
+                                .build()
+                ));
     }
 
-    /**
-     * [메서드 레벨]
-     * 로그인 응답 생성
-     */
     private LoginResponse buildLoginResponse(CustomMemberDetails userDetails, String token) {
         return LoginResponse.builder()
-                .message("로그인 성공")
+                .message("Login success")
                 .accessToken(token)
                 .user(LoginResponse.UserInfo.builder()
                         .id(String.valueOf(userDetails.getId()))

--- a/src/main/java/com/team1/epilogue/auth/service/MemberService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/MemberService.java
@@ -4,7 +4,15 @@ import com.team1.epilogue.auth.dto.RegisterRequest;
 import com.team1.epilogue.auth.dto.MemberResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
-import com.team1.epilogue.auth.exception.*;
+import com.team1.epilogue.auth.exception.EmailAlreadyExistException;
+import com.team1.epilogue.auth.exception.IdAlreadyExistException;
+import com.team1.epilogue.auth.exception.InvalidBirthDateFormatException;
+import com.team1.epilogue.auth.exception.InvalidEmailFormatException;
+import com.team1.epilogue.auth.exception.InvalidPasswordException;
+import com.team1.epilogue.auth.exception.InvalidPhoneFormatException;
+import com.team1.epilogue.auth.exception.MissingRequiredFieldException;
+import com.team1.epilogue.auth.exception.NicknameAlreadyExistsException;
+import com.team1.epilogue.auth.exception.MemberNotFoundException;
 import com.team1.epilogue.auth.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -20,15 +28,14 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
 
-    /**
-     * [메서드 레벨]
-     * 회원가입 요청(RegisterRequest)을 처리하여 회원 정보를 저장하고,
-     * 저장된 정보를 MemberResponse DTO로 반환하는 메서드.
-     */
     public MemberResponse registerMember(RegisterRequest request) {
-
         validateRegisterRequest(request);
-// RegisterRequest를 Member 엔티티로 변환
+        if (memberRepository.existsByLoginId(request.getLoginId())) {
+            throw new IdAlreadyExistException();
+        }
+        if (memberRepository.existsByEmail(request.getEmail())) {
+            throw new EmailAlreadyExistException();
+        }
         Member member = Member.builder()
                 .loginId(request.getLoginId())
                 .password(passwordEncoder.encode(request.getPassword()))
@@ -41,11 +48,7 @@ public class MemberService {
                 .point(0)
                 .social(null)
                 .build();
-
-        // 회원 정보 저장
         Member savedMember = memberRepository.save(member);
-
-        // 저장된 정보를 MemberResponse로 변환하여 반환
         return MemberResponse.builder()
                 .id(String.valueOf(savedMember.getId()))
                 .loginId(savedMember.getLoginId())
@@ -58,72 +61,50 @@ public class MemberService {
                 .build();
     }
 
-/**
- * [메서드 레벨]
- * 회원가입 요청 데이터 검증
- */
-        private void validateRegisterRequest(RegisterRequest request) {
-            if (request.getLoginId() == null || request.getLoginId().isBlank()) {
-                throw new MissingRequiredFieldException();
-            }
-            if (request.getPassword() == null || request.getPassword().length() < 6) {
-                throw new InvalidPasswordException();
-            }
-            if (request.getNickname() == null || request.getNickname().isBlank()) {
-                throw new MissingRequiredFieldException();
-            }
-            if (request.getName() == null || request.getName().isBlank()) {
-                throw new MissingRequiredFieldException();
-            }
-            if (request.getEmail() == null || request.getEmail().isBlank() || !Pattern.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$", request.getEmail())) {
-                throw new InvalidEmailFormatException();
-            }
-            if (request.getPhone() == null || request.getPhone().isBlank() || !Pattern.matches("\\d{2,3}-\\d{3,4}-\\d{4}", request.getPhone())) {
-                throw new InvalidPhoneFormatException();
-            }
-            if (request.getBirthDate() == null || request.getBirthDate().isBlank() || !Pattern.matches("\\d{4}-\\d{2}-\\d{2}", request.getBirthDate())) {
-                throw new InvalidBirthDateFormatException();
-            }
+    private void validateRegisterRequest(RegisterRequest request) {
+        if (request.getLoginId() == null || request.getLoginId().isBlank()) {
+            throw new MissingRequiredFieldException();
         }
+        if (request.getPassword() == null || request.getPassword().length() < 6) {
+            throw new InvalidPasswordException();
+        }
+        if (request.getNickname() == null || request.getNickname().isBlank()) {
+            throw new MissingRequiredFieldException();
+        }
+        if (request.getName() == null || request.getName().isBlank()) {
+            throw new MissingRequiredFieldException();
+        }
+        if (request.getEmail() == null || request.getEmail().isBlank() ||
+                !Pattern.matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$", request.getEmail())) {
+            throw new InvalidEmailFormatException();
+        }
+        if (request.getPhone() == null || request.getPhone().isBlank() ||
+                !Pattern.matches("\\d{2,3}-\\d{3,4}-\\d{4}", request.getPhone())) {
+            throw new InvalidPhoneFormatException();
+        }
+        if (request.getBirthDate() == null || request.getBirthDate().isBlank() ||
+                !Pattern.matches("\\d{4}-\\d{2}-\\d{2}", request.getBirthDate())) {
+            throw new InvalidBirthDateFormatException();
+        }
+    }
 
-    /**
-     * [메서드 레벨]
-     * 회원정보 수정 요청을 처리하여 회원의 닉네임, 이메일, 전화번호, 프로필 사진 정보를 업데이트하고,
-     * 업데이트된 정보를 MemberResponse로 반환하는 메서드.
-     *
-     * @param memberId 수정할 회원의 ID
-     * @param request  업데이트할 회원정보가 담긴 DTO
-     * @return 업데이트된 회원 정보를 담은 MemberResponse
-     */
     public MemberResponse updateMember(Long memberId, UpdateMemberRequest request) {
-        // 회원 조회
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException("회원이 존재하지 않습니다."));
-
-        // 이메일 형식 검증
         if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
             throw new InvalidEmailFormatException();
         }
-        // 이메일 중복 체크: 현재 회원이 아닌 다른 회원이 해당 이메일을 사용 중이면 오류 발생
         memberRepository.findByEmail(request.getEmail())
                 .filter(m -> !m.getId().equals(memberId))
                 .ifPresent(m -> { throw new EmailAlreadyExistException(); });
-
-        // 닉네임 중복 체크
         memberRepository.findByNickname(request.getNickname())
                 .filter(m -> !m.getId().equals(memberId))
                 .ifPresent(m -> { throw new NicknameAlreadyExistsException(); });
-
-    // 회원 정보 업데이트
         member.setNickname(request.getNickname());
         member.setEmail(request.getEmail());
         member.setPhone(request.getPhone());
         member.setProfileUrl(request.getProfilePhoto());
-
-        // 업데이트된 회원 정보 저장
         Member updatedMember = memberRepository.save(member);
-
-        // 업데이트된 정보를 MemberResponse DTO로 변환하여 반환
         return MemberResponse.builder()
                 .id(String.valueOf(updatedMember.getId()))
                 .loginId(updatedMember.getLoginId())
@@ -136,19 +117,12 @@ public class MemberService {
                 .build();
     }
 
-    /**
-     * [메서드 레벨]
-     *
-     * 소셜 회원가입:
-     * - 이메일을 기준으로 이미 등록되어 있다면 해당 회원을 반환
-     * - 등록되어 있지 않으면 신규 회원으로 등록
-     */
     public Member findOrCreateSocialMember(String email, String loginId, String name, String profileUrl, String socialType) {
         return memberRepository.findByEmail(email)
                 .orElseGet(() -> memberRepository.save(
                         Member.builder()
                                 .loginId(loginId)
-                                .password("")  // 소셜 회원은 비밀번호 없이 가입
+                                .password("")
                                 .nickname(name)
                                 .name(name)
                                 .email(email)

--- a/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
+++ b/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
@@ -12,6 +12,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+/**
+ * [클래스 레벨]
+ * 팔로우 관련 기능을 제공하는 컨트롤러
+ * 사용자를 팔로우 및 언팔로우
+ * 특정 사용자의 팔로워 및 팔로잉 목록 조회
+ * 팔로우한 사용자의 리뷰 조회
+ *
+ * 인증된 사용자만 API를 사용할 수 있으며, 로그인된 사용자의 정보를 SecurityContextHolder에서 가져옴
+ */
 @RestController
 @RequestMapping("/api/follows")
 public class FollowController {
@@ -22,14 +31,26 @@ public class FollowController {
         this.followService = followService;
     }
 
-    // 팔로우 등록
+    /**
+     * [메서드 레벨]
+     * 특정 사용자를 팔로우
+     *
+     * @param targetLoginId 팔로우할 사용자의 로그인 ID
+     * @return 팔로우 성공 응답 (팔로워, 팔로우된 사용자 정보 포함)
+     */
     @PostMapping("/{targetLoginId}")
     public FollowActionResponse followUser(@PathVariable("targetLoginId") String targetLoginId) {
         String currentLoginId = getCurrentLoginId();
         return followService.followUser(currentLoginId, targetLoginId);
     }
 
-    // 팔로우 삭제
+    /**
+     * [메서드 레벨]
+     * 특정 사용자의 팔로우를 해제
+     *
+     * @param targetLoginId 언팔로우할 사용자의 로그인 ID
+     * @return 언팔로우 성공 메시지 응답
+     */
     @DeleteMapping("/{targetLoginId}")
     public MessageResponse unfollowUser(@PathVariable("targetLoginId") String targetLoginId) {
         String currentLoginId = getCurrentLoginId();
@@ -37,7 +58,15 @@ public class FollowController {
         return new MessageResponse("팔로우 삭제 성공");
     }
 
-    // 팔로워/팔로잉 목록 조회
+    /**
+     * [메서드 레벨]
+     * 특정 사용자의 팔로워 또는 팔로잉 목록 조회
+     *
+     * @param loginId 조회할 사용자의 로그인 ID
+     * @param type 조회할 목록 유형 (following 또는 followers)
+     * @return 해당 목록의 사용자 정보 리스트
+     * @throws ResponseStatusException 잘못된 쿼리 파라미터 입력 시 400 에러 반환
+     */
     @GetMapping("/{loginId}")
     public MembersResponse getFollowList(@PathVariable("loginId") String loginId,
                                          @RequestParam("type") String type) {
@@ -50,7 +79,15 @@ public class FollowController {
         }
     }
 
-    // 팔로우한 회원의 리뷰 조회
+    /**
+     * [메서드 레벨]
+     * 로그인한 사용자가 팔로우한 사용자의 리뷰를 조회
+     *
+     * @param page 페이지 번호
+     * @param limit 페이지당 아이템 수
+     * @param sort 정렬 순서 (asc 또는 desc)
+     * @return 팔로우한 사용자의 리뷰 리스트
+     */
     @GetMapping("/review")
     public ReviewListResponse getFollowedReviews(@RequestParam("page") int page,
                                                  @RequestParam("limit") int limit,
@@ -59,6 +96,13 @@ public class FollowController {
         return followService.getFollowedReviews(currentLoginId, page, limit, sort);
     }
 
+    /**
+     * [메서드 레벨]
+     * 현재 로그인한 사용자의 ID를 가져옴
+     *
+     * @return 현재 로그인한 사용자의 ID
+     * @throws ResponseStatusException 인증되지 않은 경우 401 에러 발생
+     */
     private String getCurrentLoginId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null || !authentication.isAuthenticated()) {
@@ -76,5 +120,4 @@ public class FollowController {
         }
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보를 확인할 수 없습니다.");
     }
-
 }

--- a/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
+++ b/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
@@ -68,9 +68,13 @@ public class FollowController {
         if (principal instanceof CustomMemberDetails) {
             return ((CustomMemberDetails) principal).getUsername();
         }
+        if (principal instanceof org.springframework.security.core.userdetails.User) {
+            return ((org.springframework.security.core.userdetails.User) principal).getUsername();
+        }
         if (principal instanceof String) {
             return (String) principal;
         }
         throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보를 확인할 수 없습니다.");
     }
+
 }

--- a/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
+++ b/src/main/java/com/team1/epilogue/follow/controller/FollowController.java
@@ -1,0 +1,76 @@
+package com.team1.epilogue.follow.controller;
+
+import com.team1.epilogue.auth.security.CustomMemberDetails;
+import com.team1.epilogue.follow.dto.FollowActionResponse;
+import com.team1.epilogue.follow.dto.MessageResponse;
+import com.team1.epilogue.follow.dto.MembersResponse;
+import com.team1.epilogue.follow.dto.ReviewListResponse;
+import com.team1.epilogue.follow.service.FollowService;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequestMapping("/api/follows")
+public class FollowController {
+
+    private final FollowService followService;
+
+    public FollowController(FollowService followService) {
+        this.followService = followService;
+    }
+
+    // 팔로우 등록
+    @PostMapping("/{targetLoginId}")
+    public FollowActionResponse followUser(@PathVariable("targetLoginId") String targetLoginId) {
+        String currentLoginId = getCurrentLoginId();
+        return followService.followUser(currentLoginId, targetLoginId);
+    }
+
+    // 팔로우 삭제
+    @DeleteMapping("/{targetLoginId}")
+    public MessageResponse unfollowUser(@PathVariable("targetLoginId") String targetLoginId) {
+        String currentLoginId = getCurrentLoginId();
+        followService.unfollowUser(currentLoginId, targetLoginId);
+        return new MessageResponse("팔로우 삭제 성공");
+    }
+
+    // 팔로워/팔로잉 목록 조회
+    @GetMapping("/{loginId}")
+    public MembersResponse getFollowList(@PathVariable("loginId") String loginId,
+                                         @RequestParam("type") String type) {
+        if ("following".equalsIgnoreCase(type)) {
+            return new MembersResponse(followService.getFollowingList(loginId));
+        } else if ("followers".equalsIgnoreCase(type)) {
+            return new MembersResponse(followService.getFollowersList(loginId));
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터");
+        }
+    }
+
+    // 팔로우한 회원의 리뷰 조회
+    @GetMapping("/review")
+    public ReviewListResponse getFollowedReviews(@RequestParam("page") int page,
+                                                 @RequestParam("limit") int limit,
+                                                 @RequestParam("sort") String sort) {
+        String currentLoginId = getCurrentLoginId();
+        return followService.getFollowedReviews(currentLoginId, page, limit, sort);
+    }
+
+    private String getCurrentLoginId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다.");
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomMemberDetails) {
+            return ((CustomMemberDetails) principal).getUsername();
+        }
+        if (principal instanceof String) {
+            return (String) principal;
+        }
+        throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "인증 정보를 확인할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/FollowActionResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/FollowActionResponse.java
@@ -3,6 +3,16 @@ package com.team1.epilogue.follow.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+
+/**
+ * [클래스 레벨]
+ * FollowActionResponse 클래스는 팔로우 또는 언팔로우 요청의 응답 데이터를 담는 DTO
+ *
+ * 필드:
+ * - message: 요청 처리 결과 메시지 (예: "팔로우 생성 성공", "팔로우 삭제 성공")
+ * - followerLoginId: 팔로우를 수행한 사용자의 로그인 ID
+ * - followedLoginId: 팔로우된 사용자의 로그인 ID
+ */
 @Data
 @AllArgsConstructor
 public class FollowActionResponse {

--- a/src/main/java/com/team1/epilogue/follow/dto/FollowActionResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/FollowActionResponse.java
@@ -1,0 +1,12 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class FollowActionResponse {
+    private String message;
+    private String followerLoginId;
+    private String followedLoginId;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/MemberDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MemberDto.java
@@ -3,6 +3,16 @@ package com.team1.epilogue.follow.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * [클래스 레벨]
+ * 회원 정보를 담는 DTO.
+ *
+ * 필드:
+ * - id: 회원의 고유 식별자
+ * - loginId: 회원의 로그인 ID
+ * - nickname: 회원의 닉네임
+ * - profileUrl: 회원의 프로필 이미지 URL
+ */
 @Data
 @AllArgsConstructor
 public class MemberDto {

--- a/src/main/java/com/team1/epilogue/follow/dto/MemberDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MemberDto.java
@@ -1,0 +1,13 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MemberDto {
+    private String id;
+    private String loginId;
+    private String nickname;
+    private String profileUrl;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/MembersResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MembersResponse.java
@@ -4,6 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import java.util.List;
 
+/**
+ * [클래스 레벨]
+ * 여러 회원 정보를 담아 반환하는 DTO.
+ *
+ * 필드:
+ * - members: 회원 목록 (MemberDto 리스트)
+ */
 @Data
 @AllArgsConstructor
 public class MembersResponse {

--- a/src/main/java/com/team1/epilogue/follow/dto/MembersResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MembersResponse.java
@@ -1,0 +1,11 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class MembersResponse {
+    private List<MemberDto> members;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/MessageResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MessageResponse.java
@@ -1,0 +1,10 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class MessageResponse {
+    private String message;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/MessageResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/MessageResponse.java
@@ -3,6 +3,13 @@ package com.team1.epilogue.follow.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * [클래스 레벨]
+ * 메시지 응답을 위한 DTO.
+ *
+ * 필드:
+ * - message: 응답 메시지 (예: "성공", "실패" 등)
+ */
 @Data
 @AllArgsConstructor
 public class MessageResponse {

--- a/src/main/java/com/team1/epilogue/follow/dto/PaginationDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/PaginationDto.java
@@ -1,0 +1,12 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PaginationDto {
+    private int page;
+    private int limit;
+    private long total;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/PaginationDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/PaginationDto.java
@@ -3,6 +3,15 @@ package com.team1.epilogue.follow.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * [클래스 레벨]
+ * 페이지네이션 정보를 담는 DTO.
+ *
+ * 필드:
+ * - page: 현재 페이지 번호
+ * - limit: 한 페이지에 보여줄 항목 개수
+ * - total: 전체 항목 개수
+ */
 @Data
 @AllArgsConstructor
 public class PaginationDto {

--- a/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
@@ -1,0 +1,15 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ReviewDto {
+    private String id;
+    private String bookId;
+    private String content;
+    private String imageUrl;
+    private String createdAt;
+    private MemberDto member;
+}

--- a/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
@@ -3,6 +3,18 @@ package com.team1.epilogue.follow.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+/**
+ * [클래스 레벨]
+ * 리뷰 정보를 담는 DTO.
+ *
+ * 필드:
+ * - id: 리뷰의 고유 식별자
+ * - bookId: 해당 리뷰가 작성된 책의 고유 ID
+ * - content: 리뷰 내용
+ * - imageUrl: 리뷰에 포함된 이미지 URL (선택적)
+ * - createdAt: 리뷰 작성 날짜 및 시간
+ * - member: 리뷰 작성자의 정보 (MemberDto 객체)
+ */
 @Data
 @AllArgsConstructor
 public class ReviewDto {

--- a/src/main/java/com/team1/epilogue/follow/dto/ReviewListResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/ReviewListResponse.java
@@ -1,9 +1,18 @@
+
 package com.team1.epilogue.follow.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import java.util.List;
 
+/**
+ * [클래스 레벨]
+ * 여러 개의 리뷰 정보를 포함하는 DTO.
+ *
+ * 필드:
+ * - review: 리뷰 목록 (ReviewDto 객체 리스트)
+ * - pagination: 페이지네이션 정보 (PaginationDto 객체)
+ */
 @Data
 @AllArgsConstructor
 public class ReviewListResponse {

--- a/src/main/java/com/team1/epilogue/follow/dto/ReviewListResponse.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/ReviewListResponse.java
@@ -1,0 +1,12 @@
+package com.team1.epilogue.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ReviewListResponse {
+    private List<ReviewDto> review;
+    private PaginationDto pagination;
+}

--- a/src/main/java/com/team1/epilogue/follow/entity/Follow.java
+++ b/src/main/java/com/team1/epilogue/follow/entity/Follow.java
@@ -5,6 +5,15 @@ import lombok.*;
 
 import jakarta.persistence.*;
 
+/**
+ * [클래스 레벨]
+ * 회원 간의 팔로우 관계를 나타냄
+ *
+ * 필드:
+ * - id: 팔로우 관계의 고유 식별자
+ * - follower: 팔로우 요청을 보낸 회원
+ * - followed: 팔로우 당하는 회원
+ */
 @Entity
 @Table(name = "follows", uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id", "followed_id"}))
 @Data
@@ -17,12 +26,10 @@ public class Follow {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 팔로워: 팔로우 요청한 회원
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id", nullable = false)
     private Member follower;
 
-    // 팔로우 대상: 팔로우 당하는 회원
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "followed_id", nullable = false)
     private Member followed;

--- a/src/main/java/com/team1/epilogue/follow/entity/Follow.java
+++ b/src/main/java/com/team1/epilogue/follow/entity/Follow.java
@@ -1,0 +1,29 @@
+package com.team1.epilogue.follow.entity;
+
+import com.team1.epilogue.auth.entity.Member;
+import lombok.*;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "follows", uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id", "followed_id"}))
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 팔로워: 팔로우 요청한 회원
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private Member follower;
+
+    // 팔로우 대상: 팔로우 당하는 회원
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "followed_id", nullable = false)
+    private Member followed;
+}

--- a/src/main/java/com/team1/epilogue/follow/exception/AlreadyFollowingException.java
+++ b/src/main/java/com/team1/epilogue/follow/exception/AlreadyFollowingException.java
@@ -1,0 +1,16 @@
+package com.team1.epilogue.follow.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * [클래스 레벨]
+ * 이미 팔로우한 회원을 다시 팔로우하려고 할 때 발생하는 예외
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class AlreadyFollowingException extends RuntimeException {
+
+    public AlreadyFollowingException() {
+        super("이미 팔로우 상태입니다.");
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/exception/FollowNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/follow/exception/FollowNotFoundException.java
@@ -1,0 +1,16 @@
+package com.team1.epilogue.follow.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * [클래스 레벨]
+ * 팔로우 관계가 존재하지 않을 때 발생하는 예외
+ */
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class FollowNotFoundException extends RuntimeException {
+
+    public FollowNotFoundException() {
+        super("팔로우 관계가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/exception/MemberNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/follow/exception/MemberNotFoundException.java
@@ -1,0 +1,16 @@
+package com.team1.epilogue.follow.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * [클래스 레벨]
+ * 요청한 회원을 찾을 수 없을 때 발생하는 예외
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class MemberNotFoundException extends RuntimeException {
+
+    public MemberNotFoundException() {
+        super("대상 사용자가 존재하지 않습니다.");
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/exception/UnauthorizedAccessException.java
+++ b/src/main/java/com/team1/epilogue/follow/exception/UnauthorizedAccessException.java
@@ -1,0 +1,16 @@
+package com.team1.epilogue.follow.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * [클래스 레벨]
+ * 인증되지 않은 사용자가 요청을 보낼 경우 발생하는 예외
+ */
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthorizedAccessException extends RuntimeException {
+
+    public UnauthorizedAccessException() {
+        super("잘못된 인증");
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
+++ b/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
@@ -7,15 +7,20 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * [클래스 레벨]
+ * FollowRepository는 회원 간의 팔로우 관계를 관리하는 JPA 리포지토리이
+ *
+ * 주요 기능:
+ * - 특정 회원이 특정 회원을 팔로우했는지 확인
+ * - 특정 회원이 팔로우한 회원 목록 조회
+ * - 특정 회원을 팔로우하는 회원 목록 조회
+ * - 팔로우 관계 삭제
+ */
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     Optional<Follow> findByFollowerAndFollowed(Member follower, Member followed);
-
-    // 팔로잉 목록
     List<Follow> findByFollower(Member follower);
-
-    // 팔로워 목록
     List<Follow> findByFollowed(Member followed);
-
     void deleteByFollowerAndFollowed(Member follower, Member followed);
 }

--- a/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
+++ b/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
@@ -1,0 +1,21 @@
+package com.team1.epilogue.follow.repository;
+
+import com.team1.epilogue.follow.entity.Follow;
+import com.team1.epilogue.auth.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    Optional<Follow> findByFollowerAndFollowed(Member follower, Member followed);
+
+    // 팔로잉 목록
+    List<Follow> findByFollower(Member follower);
+
+    // 팔로워 목록
+    List<Follow> findByFollowed(Member followed);
+
+    void deleteByFollowerAndFollowed(Member follower, Member followed);
+}

--- a/src/main/java/com/team1/epilogue/follow/service/FollowService.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowService.java
@@ -1,0 +1,16 @@
+package com.team1.epilogue.follow.service;
+
+import com.team1.epilogue.follow.dto.FollowActionResponse;
+import com.team1.epilogue.follow.dto.MessageResponse;
+import com.team1.epilogue.follow.dto.MemberDto;
+import com.team1.epilogue.follow.dto.ReviewListResponse;
+
+import java.util.List;
+
+public interface FollowService {
+    FollowActionResponse followUser(String followerLoginId, String targetLoginId);
+    void unfollowUser(String followerLoginId, String targetLoginId);
+    List<MemberDto> getFollowingList(String loginId);
+    List<MemberDto> getFollowersList(String loginId);
+    ReviewListResponse getFollowedReviews(String currentLoginId, int page, int limit, String sort);
+}

--- a/src/main/java/com/team1/epilogue/follow/service/FollowService.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowService.java
@@ -1,12 +1,22 @@
 package com.team1.epilogue.follow.service;
 
 import com.team1.epilogue.follow.dto.FollowActionResponse;
-import com.team1.epilogue.follow.dto.MessageResponse;
 import com.team1.epilogue.follow.dto.MemberDto;
 import com.team1.epilogue.follow.dto.ReviewListResponse;
 
 import java.util.List;
 
+/**
+ * [클래스 레벨]
+ * FollowService는 회원 간 팔로우 관련 기능을 제공하는 서비스 인터페이스
+ *
+ * 주요 기능:
+ * - 회원 팔로우
+ * - 회원 언팔로우
+ * - 특정 회원이 팔로우한 회원 목록 조회
+ * - 특정 회원을 팔로우하는 회원 목록 조회
+ * - 특정 회원이 팔로우한 회원들의 리뷰 조회
+ */
 public interface FollowService {
     FollowActionResponse followUser(String followerLoginId, String targetLoginId);
     void unfollowUser(String followerLoginId, String targetLoginId);

--- a/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
@@ -1,0 +1,127 @@
+package com.team1.epilogue.follow.service;
+
+import com.team1.epilogue.follow.dto.*;
+import com.team1.epilogue.follow.entity.Follow;
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.review.entity.Review;
+import com.team1.epilogue.follow.repository.FollowRepository;
+import com.team1.epilogue.auth.repository.MemberRepository;
+import com.team1.epilogue.review.repository.ReviewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+
+@Service
+public class FollowServiceImpl implements FollowService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+    private final ReviewRepository reviewRepository;
+
+    @Autowired
+    public FollowServiceImpl(MemberRepository memberRepository,
+                             FollowRepository followRepository,
+                             ReviewRepository reviewRepository) {
+        this.memberRepository = memberRepository;
+        this.followRepository = followRepository;
+        this.reviewRepository = reviewRepository;
+    }
+
+    @Override
+    public FollowActionResponse followUser(String followerLoginId, String targetLoginId) {
+        Member follower = memberRepository.findByLoginId(followerLoginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+        Member followed = memberRepository.findByLoginId(targetLoginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "대상 사용자가 존재하지 않음"));
+
+        followRepository.findByFollowerAndFollowed(follower, followed).ifPresent(f -> {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미 팔로우 상태입니다.");
+        });
+
+        Follow follow = Follow.builder()
+                .follower(follower)
+                .followed(followed)
+                .build();
+        followRepository.save(follow);
+        return new FollowActionResponse("팔로우 생성 성공", follower.getLoginId(), followed.getLoginId());
+    }
+
+    @Override
+    public void unfollowUser(String followerLoginId, String targetLoginId) {
+        Member follower = memberRepository.findByLoginId(followerLoginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+        Member followed = memberRepository.findByLoginId(targetLoginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "대상 사용자가 존재하지 않음"));
+
+        Follow follow = followRepository.findByFollowerAndFollowed(follower, followed)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "팔로우 관계가 존재하지 않습니다."));
+        followRepository.delete(follow);
+    }
+
+    @Override
+    public List<MemberDto> getFollowingList(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+        List<Follow> followings = followRepository.findByFollower(member);
+        return followings.stream()
+                .map(f -> convertToMemberDto(f.getFollowed()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<MemberDto> getFollowersList(String loginId) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+        List<Follow> followers = followRepository.findByFollowed(member);
+        return followers.stream()
+                .map(f -> convertToMemberDto(f.getFollower()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ReviewListResponse getFollowedReviews(String currentLoginId, int page, int limit, String sort) {
+        if (page < 1 || limit < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터");
+        }
+        Member currentMember = memberRepository.findByLoginId(currentLoginId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+        List<Follow> followings = followRepository.findByFollower(currentMember);
+        List<Member> followedMembers = followings.stream()
+                .map(Follow::getFollowed)
+                .collect(Collectors.toList());
+        if (followedMembers.isEmpty()) {
+            PaginationDto pagination = new PaginationDto(page, limit, 0);
+            return new ReviewListResponse(List.of(), pagination);
+        }
+        Sort sortObj = sort.equalsIgnoreCase("asc") ? Sort.by("createdAt").ascending() : Sort.by("createdDate").descending();
+        Pageable pageable = PageRequest.of(page - 1, limit, sortObj);
+        Page<Review> reviewPage = reviewRepository.findByMemberIn(followedMembers, pageable);
+        List<ReviewDto> reviewDtos = reviewPage.stream()
+                .map(this::convertToReviewDto)
+                .collect(Collectors.toList());
+        PaginationDto pagination = new PaginationDto(page, limit, reviewPage.getTotalElements());
+        return new ReviewListResponse(reviewDtos, pagination);
+    }
+
+    private MemberDto convertToMemberDto(Member member) {
+        return new MemberDto(String.valueOf(member.getId()), member.getLoginId(), member.getNickname(), member.getProfileUrl());
+    }
+
+    private ReviewDto convertToReviewDto(Review review) {
+        return new ReviewDto(
+                String.valueOf(review.getId()),
+                String.valueOf(review.getBook().getId()),
+                review.getContent(),
+                review.getImageUrl(),
+                review.getCreatedAt() != null ? review.getCreatedAt().toString() : null,
+                convertToMemberDto(review.getMember())
+        );
+    }
+}

--- a/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
@@ -16,8 +16,14 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
-
+/**
+ * [클래스 레벨]
+ * FollowService의 구현체로, 팔로우 관련 비즈니스 로직을 처리하는 서비스 클래스
+ *
+ * - 회원 팔로우 및 언팔로우
+ * - 팔로잉 및 팔로워 목록 조회
+ * - 팔로우한 회원들의 리뷰 조회
+ */
 @Service
 public class FollowServiceImpl implements FollowService {
 
@@ -34,6 +40,14 @@ public class FollowServiceImpl implements FollowService {
         this.reviewRepository = reviewRepository;
     }
 
+    /**
+     * [메서드 레벨]
+     * 회원이 다른 회원을 팔로우
+     *
+     * @param followerLoginId 팔로우 요청을 보낸 회원의 로그인 ID
+     * @param targetLoginId 팔로우 대상 회원의 로그인 ID
+     * @return FollowActionResponse 팔로우 성공 메시지와 관련 정보
+     */
     @Override
     public FollowActionResponse followUser(String followerLoginId, String targetLoginId) {
         Member follower = memberRepository.findByLoginId(followerLoginId)
@@ -53,6 +67,13 @@ public class FollowServiceImpl implements FollowService {
         return new FollowActionResponse("팔로우 생성 성공", follower.getLoginId(), followed.getLoginId());
     }
 
+    /**
+     * [메서드 레벨]
+     * 회원이 특정 회원을 언팔로우
+     *
+     * @param followerLoginId 언팔로우 요청을 보낸 회원의 로그인 ID
+     * @param targetLoginId 언팔로우 대상 회원의 로그인 ID
+     */
     @Override
     public void unfollowUser(String followerLoginId, String targetLoginId) {
         Member follower = memberRepository.findByLoginId(followerLoginId)
@@ -65,59 +86,107 @@ public class FollowServiceImpl implements FollowService {
         followRepository.delete(follow);
     }
 
+    /**
+     * [메서드 레벨]
+     * 특정 회원이 팔로우한 회원 목록을 조회
+     *
+     * @param loginId 조회할 회원의 로그인 ID
+     * @return List<MemberDto> 팔로우한 회원들의 목록
+     */
     @Override
     public List<MemberDto> getFollowingList(String loginId) {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+
         List<Follow> followings = followRepository.findByFollower(member);
         return followings.stream()
                 .map(f -> convertToMemberDto(f.getFollowed()))
                 .collect(Collectors.toList());
     }
 
+    /**
+     * [메서드 레벨]
+     * 특정 회원을 팔로우하는 회원 목록을 조회
+     *
+     * @param loginId 조회할 회원의 로그인 ID
+     * @return List<MemberDto> 팔로우하는 회원들의 목록
+     */
     @Override
     public List<MemberDto> getFollowersList(String loginId) {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+
         List<Follow> followers = followRepository.findByFollowed(member);
         return followers.stream()
                 .map(f -> convertToMemberDto(f.getFollower()))
                 .collect(Collectors.toList());
     }
 
+    /**
+     * [메서드 레벨]
+     * 특정 회원이 팔로우한 회원들의 리뷰 목록을 조회
+     *
+     * @param currentLoginId 조회를 요청한 회원의 로그인 ID
+     * @param page 요청 페이지 번호 (1 이상)
+     * @param limit 페이지당 리뷰 개수 (1 이상)
+     * @param sort 정렬 방식 ("asc" 또는 "desc")
+     * @return ReviewListResponse 팔로우한 회원들의 리뷰 목록과 페이지네이션 정보
+     */
     @Override
     public ReviewListResponse getFollowedReviews(String currentLoginId, int page, int limit, String sort) {
         if (page < 1 || limit < 1) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 쿼리 파라미터");
         }
+
         Member currentMember = memberRepository.findByLoginId(currentLoginId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "잘못된 인증"));
+
         List<Follow> followings = followRepository.findByFollower(currentMember);
         List<Member> followedMembers = followings.stream()
                 .map(Follow::getFollowed)
                 .collect(Collectors.toList());
+
         if (followedMembers.isEmpty()) {
             PaginationDto pagination = new PaginationDto(page, limit, 0);
             return new ReviewListResponse(List.of(), pagination);
         }
+
+        // 정렬 방식 결정 (기본적으로 최신순)
         Sort sortObj = sort.equalsIgnoreCase("asc") ? Sort.by("createdAt").ascending() : Sort.by("createdAt").descending();
         Pageable pageable = PageRequest.of(page - 1, limit, sortObj);
+
+        // 팔로우한 회원들의 리뷰 조회
         Page<Review> reviewPage = reviewRepository.findByMemberIn(followedMembers, pageable);
         List<ReviewDto> reviewDtos = reviewPage.stream()
                 .map(this::convertToReviewDto)
                 .collect(Collectors.toList());
+
         PaginationDto pagination = new PaginationDto(page, limit, reviewPage.getTotalElements());
         return new ReviewListResponse(reviewDtos, pagination);
     }
 
+    /**
+     * [메서드 레벨]
+     * Member 엔터티를 MemberDto로 변환
+     *
+     * @param member 변환할 Member 엔터티
+     * @return MemberDto 변환된 회원 정보 DTO
+     */
     private MemberDto convertToMemberDto(Member member) {
         return new MemberDto(String.valueOf(member.getId()), member.getLoginId(), member.getNickname(), member.getProfileUrl());
     }
 
+    /**
+     * [메서드 레벨]
+     * Review 엔터티를 ReviewDto로 변환
+     *
+     * @param review 변환할 Review 엔터티
+     * @return ReviewDto 변환된 리뷰 정보 DTO
+     */
     private ReviewDto convertToReviewDto(Review review) {
         return new ReviewDto(
                 String.valueOf(review.getId()),
-                String.valueOf(review.getBook().getId()),
+                review.getBook() != null ? String.valueOf(review.getBook().getId()) : null,
                 review.getContent(),
                 review.getImageUrl(),
                 review.getCreatedAt() != null ? review.getCreatedAt().toString() : null,

--- a/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowServiceImpl.java
@@ -100,7 +100,7 @@ public class FollowServiceImpl implements FollowService {
             PaginationDto pagination = new PaginationDto(page, limit, 0);
             return new ReviewListResponse(List.of(), pagination);
         }
-        Sort sortObj = sort.equalsIgnoreCase("asc") ? Sort.by("createdAt").ascending() : Sort.by("createdDate").descending();
+        Sort sortObj = sort.equalsIgnoreCase("asc") ? Sort.by("createdAt").ascending() : Sort.by("createdAt").descending();
         Pageable pageable = PageRequest.of(page - 1, limit, sortObj);
         Page<Review> reviewPage = reviewRepository.findByMemberIn(followedMembers, pageable);
         List<ReviewDto> reviewDtos = reviewPage.stream()

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.team1.epilogue.review.repository;
 
+import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,4 +15,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
      * @return 해당 책의 리뷰 목록 (페이징 적용)
      */
     Page<Review> findByBookId(String bookId, Pageable pageable);
+
+    // 회원 리스트에 포함된 리뷰들을 페이징 조회하는 메서드
+    Page<Review> findByMemberIn(Iterable<Member> members, Pageable pageable);
 }
+

--- a/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
@@ -1,39 +1,50 @@
 package com.team1.epilogue.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team1.epilogue.auth.entity.Member;
-import com.team1.epilogue.auth.service.*;
-import com.team1.epilogue.config.TestSecurityConfig;
+import com.team1.epilogue.auth.dto.ApiResponse;
 import com.team1.epilogue.auth.dto.GeneralLoginRequest;
+import com.team1.epilogue.auth.dto.GoogleUserInfo;
 import com.team1.epilogue.auth.dto.KakaoUserInfo;
 import com.team1.epilogue.auth.dto.LoginResponse;
+import com.team1.epilogue.auth.dto.LoginResponse.UserInfo;
+import com.team1.epilogue.auth.dto.SuccessResponse;
+import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
+import com.team1.epilogue.auth.service.AuthService;
+import com.team1.epilogue.auth.service.GoogleAuthService;
+import com.team1.epilogue.auth.service.KakaoAuthService;
+import com.team1.epilogue.auth.service.GoogleWithdrawalService;
+import com.team1.epilogue.auth.service.KakaoWithdrawalService;
+import com.team1.epilogue.auth.service.LogoutService;
+import com.team1.epilogue.auth.service.MemberWithdrawalService;
+import com.team1.epilogue.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
-/**
- * [클래스 레벨]
- * AuthController의 단위 테스트 클래스
- * - 로그인, 소셜 로그인, 소셜 회원 탈퇴 기능을 테스트
- */
 @WebMvcTest(AuthController.class)
 @Import(TestSecurityConfig.class)
+@DisplayName("AuthController 테스트")
 public class AuthControllerTest {
 
     @Autowired
@@ -44,203 +55,249 @@ public class AuthControllerTest {
 
     @MockitoBean
     private AuthService authService;
-
     @MockitoBean
     private KakaoAuthService kakaoAuthService;
-
     @MockitoBean
     private GoogleAuthService googleAuthService;
-
-
-    @MockitoBean
-    private KakaoWithdrawalService kakaoWithdrawalService;
-
-    @MockitoBean
-    private GoogleWithdrawalService googleWithdrawalService;
-
-
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
-
+    @MockitoBean
+    private GoogleWithdrawalService googleWithdrawalService;
+    @MockitoBean
+    private KakaoWithdrawalService kakaoWithdrawalService;
     @MockitoBean
     private LogoutService logoutService;
-    /**
-     * [메서드 레벨]
-     * 일반 로그인 성공 테스트
-     * - 올바른 로그인 ID와 비밀번호 입력 시, 정상적으로 JWT 토큰과 사용자 정보를 반환하는지 확인
-     */
-    @Test
-    @DisplayName("일반 로그인 성공 테스트")
-    public void testLogin_Success() throws Exception {
-        GeneralLoginRequest request = new GeneralLoginRequest();
-        request.setLoginId("testUser");
-        request.setPassword("password");
 
+    @Test
+    @DisplayName("로그인 성공")
+    public void testLoginSuccess() throws Exception {
+        GeneralLoginRequest request = new GeneralLoginRequest("user1", "password");
+        UserInfo userInfo = UserInfo.builder()
+                .id("1")
+                .userId("user1")
+                .name("user1")
+                .profileImg("http://example.com/image.png")
+                .build();
         LoginResponse loginResponse = LoginResponse.builder()
-                .message("로그인 성공")
-                .accessToken("jwt-token")
-                .user(LoginResponse.UserInfo.builder()
-                        .id("1")
-                        .userId("testUser")
-                        .name("Test User")
-                        .profileImg("http://example.com/profile.jpg")
-                        .build())
+                .message("Login success")
+                .accessToken("dummyToken")
+                .user(userInfo)
                 .build();
 
-        Mockito.when(authService.login(Mockito.any(GeneralLoginRequest.class)))
-                .thenReturn(loginResponse);
+        when(authService.login(any(GeneralLoginRequest.class))).thenReturn(loginResponse);
 
         mockMvc.perform(post("/api/members/login")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("로그인 성공"))
-                .andExpect(jsonPath("$.accessToken").value("jwt-token"));
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Login success")))
+                .andExpect(jsonPath("$.data.accessToken", is("dummyToken")))
+                .andExpect(jsonPath("$.data.user.userId", is("user1")));
     }
 
-
-    /**
-     * [메서드 레벨]
-     * 카카오 소셜 로그인 성공 테스트
-     * - 카카오 API에서 인증 코드를 받아, 정상적으로 로그인 응답을 반환하는지 확인
-     */
     @Test
-    @DisplayName("카카오 소셜 로그인 콜백 성공 테스트")
-    public void testSocialLogin_KakaoCallback_Success() throws Exception {
-        String code = "sample-code";
+    @DisplayName("로그인 실패")
+    public void testLoginFailure() throws Exception {
+        GeneralLoginRequest request = new GeneralLoginRequest("user1", "wrongPassword");
+        when(authService.login(any(GeneralLoginRequest.class)))
+                .thenThrow(new BadCredentialsException("Invalid username or password."));
 
+        mockMvc.perform(post("/api/members/login")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.error", is("Invalid username or password.")));
+    }
+
+    @Test
+    @DisplayName("구글 콜백 성공")
+    public void testGoogleCallbackSuccess() throws Exception {
+        String code = "dummyCode";
+        GoogleUserInfo googleUserInfo = new GoogleUserInfo();
+        googleUserInfo.setSub("12345");
+        googleUserInfo.setEmail("test@example.com");
+        googleUserInfo.setName("user1");
+        googleUserInfo.setPicture("http://example.com/image.png");
+
+        UserInfo userInfo = UserInfo.builder()
+                .id("1")
+                .userId("google_12345")
+                .name("user1")
+                .profileImg("http://example.com/image.png")
+                .build();
+        LoginResponse loginResponse = LoginResponse.builder()
+                .message("Login success")
+                .accessToken("googleToken")
+                .user(userInfo)
+                .build();
+
+        when(googleAuthService.getGoogleUserInfo(code)).thenReturn(googleUserInfo);
+        when(authService.socialLoginGoogle(googleUserInfo)).thenReturn(loginResponse);
+
+        mockMvc.perform(get("/api/members/auth/google/callback")
+                        .param("code", code))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Login success")))
+                .andExpect(jsonPath("$.data.accessToken", is("googleToken")));
+    }
+
+    @Test
+    @DisplayName("카카오 콜백 성공")
+    public void testKakaoCallbackSuccess() throws Exception {
+        String code = "dummyKakaoCode";
+        // 카카오 사용자 정보 생성
         KakaoUserInfo kakaoUserInfo = new KakaoUserInfo();
-        kakaoUserInfo.setId(12345L);
+        kakaoUserInfo.setId(100L);
+        // 내부 클래스 KakaoAccount와 KakaoProfile 객체 생성
+        KakaoUserInfo.KakaoProfile profile = new KakaoUserInfo.KakaoProfile();
+        profile.setNickname("user1");
+        profile.setProfileImageUrl("http://example.com/kakao.png");
         KakaoUserInfo.KakaoAccount account = new KakaoUserInfo.KakaoAccount();
         account.setEmail("kakao@example.com");
-        KakaoUserInfo.KakaoProfile profile = new KakaoUserInfo.KakaoProfile();
-        profile.setNickname("KakaoUser");
-        profile.setProfileImageUrl("http://example.com/kakao.jpg");
         account.setProfile(profile);
         kakaoUserInfo.setKakao_account(account);
 
+        UserInfo userInfo = UserInfo.builder()
+                .id("1")
+                .userId("kakao_100")
+                .name("user1")
+                .profileImg("http://example.com/kakao.png")
+                .build();
         LoginResponse loginResponse = LoginResponse.builder()
-                .message("로그인 성공")
-                .accessToken("jwt-token")
-                .user(LoginResponse.UserInfo.builder()
-                        .id("1")
-                        .userId("kakao_12345")
-                        .name("KakaoUser")
-                        .profileImg("http://example.com/kakao.jpg")
-                        .build())
+                .message("Login success")
+                .accessToken("kakaoToken")
+                .user(userInfo)
                 .build();
 
-        Mockito.when(kakaoAuthService.getKakaoUserInfo(code)).thenReturn(kakaoUserInfo);
-        Mockito.when(authService.socialLoginKakao(Mockito.any(KakaoUserInfo.class)))
-                .thenReturn(loginResponse);
+        when(kakaoAuthService.getKakaoUserInfo(code)).thenReturn(kakaoUserInfo);
+        when(authService.socialLoginKakao(kakaoUserInfo)).thenReturn(loginResponse);
 
         mockMvc.perform(get("/api/members/auth/kakao/callback")
                         .param("code", code))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("로그인 성공"))
-                .andExpect(jsonPath("$.accessToken").value("jwt-token"));
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Login success")))
+                .andExpect(jsonPath("$.data.accessToken", is("kakaoToken")));
     }
 
-
-
-    // 카카오 소셜 회원 탈퇴 성공 테스트
     @Test
-    @DisplayName("카카오 소셜 회원 탈퇴 성공 테스트")
-    public void testWithdrawSocialMember_Kakao_Success() throws Exception {
-        // 인증된 사용자 생성
-        CustomMemberDetails customMemberDetails = CustomMemberDetails.fromMember(
-                Member.builder()
-                        .id(1L)
-                        .loginId("kakao_12345")
-                        .password("")
-                        .name("KakaoUser")
-                        .profileUrl("http://example.com/kakao.jpg")
-                        .build()
-        );
+    @DisplayName("로그아웃 성공")
+    public void testLogoutSuccess() throws Exception {
+        String token = "dummyToken";
+        Member dummyMember = Member.builder()
+                .id(1L)
+                .loginId("user1")
+                .password("dummyPassword")
+                .nickname("user1")
+                .name("user1")
+                .email("user1@example.com")
+                .phone("010-1111-1111")
+                .profileUrl("http://example.com/profile.png")
+                .point(0)
+                .social("local")
+                .build();
+        CustomMemberDetails userDetails = CustomMemberDetails.fromMember(dummyMember);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
 
-        mockMvc.perform(delete("/api/members/social/withdraw")
-                        .with(csrf())
-                        .param("provider", "kakao")
-                        .param("accessToken", "sample-access-token")
-                        .with(user(customMemberDetails)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("소셜 회원 탈퇴 성공"));
-    }
-
-    /**
-     * [메서드 레벨]
-     * 구글 소셜 회원 탈퇴 성공 테스트
-     * - 인증된 사용자가 구글 연동을 해제하고, DB에서 정상적으로 삭제되는지 확인
-     */
-    // 구글 소셜 회원 탈퇴 성공 테스트
-    @Test
-    @DisplayName("구글 소셜 회원 탈퇴 성공 테스트")
-    public void testWithdrawSocialMember_Google_Success() throws Exception {
-        // 인증된 사용자 생성
-        CustomMemberDetails customMemberDetails = CustomMemberDetails.fromMember(
-                Member.builder()
-                        .id(1L)
-                        .loginId("testUser")
-                        .password("")
-                        .name("Test User")
-                        .profileUrl("http://example.com/profile.jpg")
-                        .build()
-        );
-        mockMvc.perform(delete("/api/members/social/withdraw")
-                        .with(csrf())
-                        .param("provider", "google")
-                        .param("accessToken", "sample-google-access-token")
-                        .with(user(customMemberDetails)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("소셜 회원 탈퇴 성공"));
-    }
-
-    // 테스트용 인증 principal 생성 (로그아웃 테스트용)
-    private CustomMemberDetails testUser() {
-        return CustomMemberDetails.fromMember(
-                Member.builder()
-                        .id(1L)
-                        .loginId("testUser")
-                        .password("encodedPassword")
-                        .name("Test User")
-                        .profileUrl("http://example.com/profile.jpg")
-                        .build()
-        );
-    }
-
-    // 일반 로그아웃 성공 테스트
-    @Test
-    @DisplayName("일반 로그아웃 성공 테스트")
-    public void testLogout_Success() throws Exception {
-        // 인증된 사용자 시뮬레이션
-        CustomMemberDetails user = testUser();
+        Mockito.doNothing().when(logoutService).invalidate(token);
 
         mockMvc.perform(post("/api/members/logout")
                         .with(csrf())
-                        .with(user(user))
-                        .header("Authorization", "Bearer jwt-token"))
+                        .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("로그아웃 성공"));
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Logout Success")));
     }
-    @Test
-    @DisplayName("소셜 로그아웃 성공 테스트")
-    public void 소셜_로그아웃_성공_테스트() throws Exception {
-        CustomMemberDetails customMemberDetails = CustomMemberDetails.fromMember(
-                Member.builder()
-                        .id(1L)
-                        .loginId("testUser")
-                        .password("")
-                        .name("Test User")
-                        .profileUrl("http://example.com/profile.jpg")
-                        .build()
-        );
-        mockMvc.perform(post("/api/members/logout")
-                        .with(csrf())
-                        .with(user(customMemberDetails))
-                        .header("Authorization", "Bearer jwt-token"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("로그아웃 성공"));
 
+    @Test
+    @DisplayName("소셜 로그아웃 성공")
+    public void testSocialLogoutSuccess() throws Exception {
+        String token = "dummyToken";
+        Mockito.doNothing().when(logoutService).invalidate(token);
+
+        mockMvc.perform(post("/api/members/logout/social")
+                        .with(csrf())
+                        .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Social Logout Success")));
+    }
+
+
+    @Test
+    @DisplayName("소셜 회원 탈퇴 성공")
+    public void testWithdrawSocialMemberSuccess() throws Exception {
+        String provider = "google";
+        String accessToken = "dummyAccessToken";
+        Member dummyMember = Member.builder()
+                .id(1L)
+                .loginId("user1")
+                .password("dummyPassword")
+                .nickname("user1")
+                .name("user1")
+                .email("user1@example.com")
+                .phone("010-1111-1111")
+                .profileUrl("http://example.com/profile.png")
+                .point(0)
+                .social("google")
+                .build();
+        CustomMemberDetails userDetails = CustomMemberDetails.fromMember(dummyMember);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Mockito.doNothing().when(googleWithdrawalService).revokeGoogleAccount(accessToken);
+        Mockito.doNothing().when(memberWithdrawalService).withdrawMember(dummyMember.getId());
+
+        mockMvc.perform(delete("/api/members/social/withdraw")
+                        .with(csrf())
+                        .param("provider", provider)
+                        .param("accessToken", accessToken)
+                        .with(request -> {
+                            request.setUserPrincipal(auth);
+                            return request;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success", is(true)))
+                .andExpect(jsonPath("$.data.message", is("Social member withdrawal success")));
+    }
+
+    @Test
+    @DisplayName("소셜 회원 탈퇴 실패 - 지원되지 않는 제공자")
+    public void testWithdrawSocialMemberUnsupportedProvider() throws Exception {
+        String provider = "facebook";
+        String accessToken = "dummyAccessToken";
+        Member dummyMember = Member.builder()
+                .id(1L)
+                .loginId("user1")
+                .password("dummyPassword")
+                .nickname("user1")
+                .name("user1")
+                .email("user1@example.com")
+                .phone("010-1111-1111")
+                .profileUrl("http://example.com/profile.png")
+                .point(0)
+                .social("local")
+                .build();
+        CustomMemberDetails userDetails = CustomMemberDetails.fromMember(dummyMember);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        mockMvc.perform(delete("/api/members/social/withdraw")
+                        .with(csrf())
+                        .param("provider", provider)
+                        .param("accessToken", accessToken)
+                        .with(request -> {
+                            request.setUserPrincipal(auth);
+                            return request;
+                        }))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success", is(false)))
+                .andExpect(jsonPath("$.error", is("Unsupported social provider")));
     }
 }

--- a/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
@@ -217,7 +217,6 @@ public class AuthControllerTest {
     @DisplayName("소셜 로그아웃 성공")
     public void testSocialLogoutSuccess() throws Exception {
         String token = "dummyToken";
-        // 가짜 사용자 생성 및 SecurityContext 설정
         Member dummyMember = Member.builder()
                 .id(1L)
                 .loginId("user1")
@@ -232,7 +231,6 @@ public class AuthControllerTest {
         Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        // 로그아웃 서비스에 대한 모킹 처리
         Mockito.doNothing().when(logoutService).invalidate(token);
 
         mockMvc.perform(post("/api/members/logout/social")

--- a/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
@@ -150,10 +150,8 @@ public class AuthControllerTest {
     @DisplayName("카카오 콜백 성공")
     public void testKakaoCallbackSuccess() throws Exception {
         String code = "dummyKakaoCode";
-        // 카카오 사용자 정보 생성
         KakaoUserInfo kakaoUserInfo = new KakaoUserInfo();
         kakaoUserInfo.setId(100L);
-        // 내부 클래스 KakaoAccount와 KakaoProfile 객체 생성
         KakaoUserInfo.KakaoProfile profile = new KakaoUserInfo.KakaoProfile();
         profile.setNickname("user1");
         profile.setProfileImageUrl("http://example.com/kakao.png");
@@ -219,6 +217,22 @@ public class AuthControllerTest {
     @DisplayName("소셜 로그아웃 성공")
     public void testSocialLogoutSuccess() throws Exception {
         String token = "dummyToken";
+        // 가짜 사용자 생성 및 SecurityContext 설정
+        Member dummyMember = Member.builder()
+                .id(1L)
+                .loginId("user1")
+                .password("dummyPassword")
+                .nickname("user1")
+                .name("user1")
+                .email("user1@example.com")
+                .phone("010-1111-1111")
+                .profileUrl("http://example.com/profile.png")
+                .build();
+        CustomMemberDetails userDetails = CustomMemberDetails.fromMember(dummyMember);
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        // 로그아웃 서비스에 대한 모킹 처리
         Mockito.doNothing().when(logoutService).invalidate(token);
 
         mockMvc.perform(post("/api/members/logout/social")

--- a/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
@@ -43,7 +43,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * MemberController의 단위 테스트 클래스
  * - 회원 가입, 회원 탈퇴, 회원 정보 수정 기능을 테스트
  */
-@Import(TestSecurityConfig.class)  // 테스트용 SecurityConfig 포함
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MemberController.class)
 @DisplayName("MemberController 테스트")
 public class MemberControllerTest {
@@ -60,11 +60,7 @@ public class MemberControllerTest {
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
 
-    // SecurityConfig에서 요구하는 CustomUserDetailsService 빈 모킹
     @MockitoBean
-    private CustomUserDetailsService customUserDetailsService;
-
-    // 인증된 사용자를 위한 CustomMemberDetails
     private CustomMemberDetails memberDetails;
 
     @BeforeEach
@@ -80,7 +76,7 @@ public class MemberControllerTest {
                 .profileUrl("http://example.com/profile.jpg")
                 .build();
         memberDetails = new CustomMemberDetails(
-                dummyMember,                         // Member 객체 전달
+                dummyMember,
                 dummyMember.getId(),
                 dummyMember.getLoginId(),
                 dummyMember.getPassword(),
@@ -197,7 +193,6 @@ public class MemberControllerTest {
     @Test
     @DisplayName("회원 탈퇴 실패 - 인증되지 않은 사용자")
     void testWithdrawMember_Unauthorized() throws Exception {
-        // 인증되지 않은 경우
         mockMvc.perform(delete("/api/members")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized())
@@ -217,7 +212,6 @@ public class MemberControllerTest {
         request.setEmail("fail@example.com");
         request.setPhone("010-0000-0000");
         request.setProfilePhoto("http://example.com/fail.jpg");
-        // 인증되지 않은 경우
         mockMvc.perform(put("/api/members")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -225,5 +219,4 @@ public class MemberControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.메시지").value("인증되지 않은 사용자"));
     }
-
 }

--- a/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
@@ -1,44 +1,51 @@
 package com.team1.epilogue.auth.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.team1.epilogue.auth.dto.ApiResponse;
 import com.team1.epilogue.auth.dto.MemberResponse;
 import com.team1.epilogue.auth.dto.RegisterRequest;
 import com.team1.epilogue.auth.dto.SuccessResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
+import com.team1.epilogue.auth.security.CustomUserDetailsService;
 import com.team1.epilogue.auth.service.MemberService;
 import com.team1.epilogue.auth.service.MemberWithdrawalService;
 import com.team1.epilogue.config.TestSecurityConfig;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.is;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * MemberController의 단위 테스트 클래스
+ * - 회원 가입, 회원 탈퇴, 회원 정보 수정 기능을 테스트
+ */
+@Import(TestSecurityConfig.class)  // 테스트용 SecurityConfig 포함
 @WebMvcTest(MemberController.class)
-@Import(TestSecurityConfig.class)
-@DisplayName("MemberController 전체 테스트")
+@DisplayName("MemberController 테스트")
 public class MemberControllerTest {
 
     @Autowired
@@ -53,166 +60,170 @@ public class MemberControllerTest {
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
 
-    // 인증된 사용자 생성 헬퍼 메서드
-    private CustomMemberDetails getAuthenticatedUser() {
-        Member dummyMember = Member.builder()
-                .id(1L)
-                .loginId("user1")
-                .password("password")
-                .nickname("user1")
-                .name("User One")
-                .email("user1@example.com")
-                .phone("010-1111-1111")
-                .profileUrl("http://example.com/profile.png")
-                // 만약 birthDate 필드가 있다면 예: .birthDate("2000-01-01")
-                .build();
-        return CustomMemberDetails.fromMember(dummyMember);
-    }
+    // SecurityConfig에서 요구하는 CustomUserDetailsService 빈 모킹
+    @MockitoBean
+    private CustomUserDetailsService customUserDetailsService;
+
+    // 인증된 사용자를 위한 CustomMemberDetails
+    private CustomMemberDetails memberDetails;
 
     @BeforeEach
-    public void setUpSecurityContext() {
-        // 필요한 테스트에서 인증이 필요한 경우 setUpSecurityContext() 호출
-        CustomMemberDetails customMemberDetails = getAuthenticatedUser();
-        UsernamePasswordAuthenticationToken auth =
-                new UsernamePasswordAuthenticationToken(customMemberDetails, null, customMemberDetails.getAuthorities());
-        SecurityContextHolder.getContext().setAuthentication(auth);
+    void setUp() {
+        Member dummyMember = Member.builder()
+                .id(1L)
+                .loginId("testUser")
+                .password("password")
+                .nickname("user1")
+                .name("Test User")
+                .email("test@example.com")
+                .phone("010-1111-1111")
+                .profileUrl("http://example.com/profile.jpg")
+                .build();
+        memberDetails = new CustomMemberDetails(
+                dummyMember,                         // Member 객체 전달
+                dummyMember.getId(),
+                dummyMember.getLoginId(),
+                dummyMember.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_USER")),
+                dummyMember.getName(),
+                dummyMember.getProfileUrl()
+        );
     }
 
-    @AfterEach
-    public void clearContext() {
-        SecurityContextHolder.clearContext();
+    /**
+     * 회원 가입 성공 테스트
+     * - 회원 가입 API를 호출하여 정상적으로 가입이 이루어지는지 확인
+     */
+    @Test
+    @DisplayName("회원 가입 성공 테스트")
+    void testRegisterMember() throws Exception {
+        RegisterRequest request = new RegisterRequest();
+        request.setLoginId("testUser");
+        request.setPassword("password123");
+        request.setNickname("testNick");
+        request.setName("Test User");
+        request.setBirthDate("1990-01-01");
+        request.setEmail("test@example.com");
+        request.setPhone("010-1111-2222");
+        request.setProfileUrl("http://example.com/profile.jpg");
+
+        MemberResponse response = MemberResponse.builder()
+                .id("1")
+                .loginId("testUser")
+                .nickname("testNick")
+                .name("Test User")
+                .birthDate("1990-01-01")
+                .email("test@example.com")
+                .phone("010-1111-2222")
+                .profileUrl("http://example.com/profile.jpg")
+                .build();
+
+        when(memberService.registerMember(any(RegisterRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/members/register")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("1"))
+                .andExpect(jsonPath("$.data.loginId").value("testUser"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"));
     }
 
-    @Nested
-    @DisplayName("회원가입 API")
-    class RegisterMemberTests {
-        @Test
-        @DisplayName("회원가입 성공")
-        public void testRegisterMemberSuccess() throws Exception {
-            RegisterRequest request = new RegisterRequest();
-            request.setLoginId("user1");
-            request.setPassword("password");
-            request.setName("User One");
-            request.setEmail("user1@example.com");
-            request.setNickname("user1");
-            request.setBirthDate("2000-01-01");
-            request.setPhone("010-1111-1111");
-            request.setProfileUrl("http://example.com/profile.png");
+    /**
+     * 회원 탈퇴 성공 테스트 (인증된 사용자)
+     * - 인증된 사용자가 정상적으로 회원 탈퇴할 수 있는지 확인
+     */
+    @Test
+    @DisplayName("회원 탈퇴 성공 테스트")
+    void testWithdrawMember() throws Exception {
+        doNothing().when(memberWithdrawalService).withdrawMember(1L);
 
-            MemberResponse memberResponse = MemberResponse.builder()
-                    .id("1")
-                    .loginId("user1")
-                    .nickname("user1")
-                    .name("User One")
-                    .birthDate("2000-01-01")
-                    .email("user1@example.com")
-                    .phone("010-1111-1111")
-                    .profileUrl("http://example.com/profile.png")
-                    .build();
+        mockMvc.perform(delete("/api/members")
+                        .with(csrf())
+                        .with(user(memberDetails)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.message").value("User account deleted successfully"));
 
-            when(memberService.registerMember(any(RegisterRequest.class))).thenReturn(memberResponse);
-
-            mockMvc.perform(post("/api/members/register")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(request)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success", is(true)))
-                    .andExpect(jsonPath("$.data.loginId", is("user1")))
-                    .andExpect(jsonPath("$.data.name", is("User One")))
-                    .andExpect(jsonPath("$.data.email", is("user1@example.com")));
-        }
+        verify(memberWithdrawalService, times(1)).withdrawMember(1L);
     }
 
-    @Nested
-    @DisplayName("회원 탈퇴 API")
-    class WithdrawMemberTests {
-        @Test
-        @DisplayName("회원 탈퇴 성공 (인증된 사용자)")
-        public void testWithdrawMemberSuccess() throws Exception {
-            CustomMemberDetails customMemberDetails = getAuthenticatedUser();
-            // 이미 setUpSecurityContext()에서 인증 정보가 설정됨
-            doNothing().when(memberWithdrawalService).withdrawMember(customMemberDetails.getId());
+    /**
+     * 회원 정보 수정 성공 테스트 (인증된 사용자)
+     * - 사용자가 자신의 정보를 정상적으로 수정할 수 있는지 확인
+     */
+    @Test
+    @DisplayName("회원 정보 수정 성공 테스트")
+    void testUpdateMember() throws Exception {
+        UpdateMemberRequest request = new UpdateMemberRequest();
+        request.setNickname("newNick");
+        request.setEmail("new@example.com");
+        request.setPhone("010-5678-1234");
+        request.setProfilePhoto("http://example.com/newProfile.jpg");
 
-            mockMvc.perform(delete("/api/members")
-                            .with(csrf()))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success", is(true)))
-                    .andExpect(jsonPath("$.data.message", is("User account deleted successfully ")));
-        }
+        MemberResponse response = MemberResponse.builder()
+                .id("1")
+                .loginId("testUser")
+                .nickname("newNick")
+                .name("Test User")
+                .birthDate("1990-01-01")
+                .email("new@example.com")
+                .phone("010-5678-1234")
+                .profileUrl("http://example.com/newProfile.jpg")
+                .build();
 
-        @Test
-        @DisplayName("회원 탈퇴 실패 (인증 미비)")
-        public void testWithdrawMemberUnauthorized() throws Exception {
-            // 인증 정보를 지우고 호출
-            SecurityContextHolder.clearContext();
-            mockMvc.perform(delete("/api/members")
-                            .with(csrf()))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.success", is(false)))
-                    .andExpect(jsonPath("$.error", is("Unauthorized user")));
-        }
+        when(memberService.updateMember(anyLong(), any(UpdateMemberRequest.class))).thenReturn(response);
+
+        mockMvc.perform(put("/api/members")
+                        .with(csrf())
+                        .with(user(memberDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value("1"))
+                .andExpect(jsonPath("$.data.nickname").value("newNick"))
+                .andExpect(jsonPath("$.data.email").value("new@example.com"))
+                .andExpect(jsonPath("$.data.phone").value("010-5678-1234"))
+                .andExpect(jsonPath("$.data.profileUrl").value("http://example.com/newProfile.jpg"));
     }
 
-    @Nested
-    @DisplayName("회원 정보 수정 API")
-    class UpdateMemberTests {
-        @Test
-        @DisplayName("회원 정보 수정 성공 (인증된 사용자)")
-        public void testUpdateMemberSuccess() throws Exception {
-            UpdateMemberRequest updateRequest = new UpdateMemberRequest();
-            updateRequest.setNickname("updatedNick");
-            updateRequest.setEmail("updated@example.com");
-            updateRequest.setPhone("010-2222-3333");
-            updateRequest.setProfilePhoto("http://example.com/updated.png");
-
-            MemberResponse updatedResponse = MemberResponse.builder()
-                    .id("1")
-                    .loginId("user1")
-                    .nickname("updatedNick")
-                    .name("User One")
-                    .birthDate("2000-01-01")
-                    .email("updated@example.com")
-                    .phone("010-2222-3333")
-                    .profileUrl("http://example.com/updated.png")
-                    .build();
-
-            when(memberService.updateMember(any(Long.class), any(UpdateMemberRequest.class)))
-                    .thenReturn(updatedResponse);
-
-            mockMvc.perform(put("/api/members")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateRequest)))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success", is(true)))
-                    .andExpect(jsonPath("$.data.nickname", is("updatedNick")))
-                    .andExpect(jsonPath("$.data.email", is("updated@example.com")))
-                    .andExpect(jsonPath("$.data.phone", is("010-2222-3333")))
-                    .andExpect(jsonPath("$.data.profileUrl", is("http://example.com/updated.png")));
-        }
-
-        @Test
-        @DisplayName("회원 정보 수정 실패 (인증 미비)")
-        public void testUpdateMemberUnauthorized() throws Exception {
-            UpdateMemberRequest updateRequest = new UpdateMemberRequest();
-            updateRequest.setNickname("updatedNick");
-            updateRequest.setEmail("updated@example.com");
-            updateRequest.setPhone("010-2222-3333");
-            updateRequest.setProfilePhoto("http://example.com/updated.png");
-            Authentication fakeAuth = mock(Authentication.class);
-            when(fakeAuth.isAuthenticated()).thenReturn(false);
-            when(fakeAuth.getPrincipal()).thenReturn("anonymous");
-
-            // 가짜 인증 정보를 SecurityContextHolder에 설정
-            SecurityContextHolder.getContext().setAuthentication(fakeAuth);
-            mockMvc.perform(put("/api/members")
-                            .with(csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateRequest)))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.success", is(false)))
-                    .andExpect(jsonPath("$.error", is("Unauthorized")));
-        }
+    /**
+     * 회원 탈퇴 실패 테스트 - 인증되지 않은 사용자
+     * - 인증되지 않은 사용자가 탈퇴 요청을 보낼 경우 실패하는지 확인
+     */
+    @Test
+    @DisplayName("회원 탈퇴 실패 - 인증되지 않은 사용자")
+    void testWithdrawMember_Unauthorized() throws Exception {
+        // 인증되지 않은 경우
+        mockMvc.perform(delete("/api/members")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.메시지").value("인증되지 않은 사용자"));
     }
+
+
+    /**
+     * 회원 정보 수정 실패 테스트 - 인증되지 않은 사용자
+     * - 인증되지 않은 사용자가 정보 수정 요청을 보낼 경우 실패하는지 확인
+     */
+    @Test
+    @DisplayName("회원 정보 수정 실패 - 인증되지 않은 사용자")
+    void testUpdateMember_Unauthorized() throws Exception {
+        UpdateMemberRequest request = new UpdateMemberRequest();
+        request.setNickname("failUser");
+        request.setEmail("fail@example.com");
+        request.setPhone("010-0000-0000");
+        request.setProfilePhoto("http://example.com/fail.jpg");
+        // 인증되지 않은 경우
+        mockMvc.perform(put("/api/members")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.메시지").value("인증되지 않은 사용자"));
+    }
+
 }

--- a/src/test/java/com/team1/epilogue/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/team1/epilogue/auth/service/AuthServiceImplTest.java
@@ -179,7 +179,7 @@ public class AuthServiceImplTest {
         KakaoUserInfo.KakaoAccount account = new KakaoUserInfo.KakaoAccount();
         account.setEmail("kakao@example.com");
         KakaoUserInfo.KakaoProfile profile = new KakaoUserInfo.KakaoProfile();
-        profile.setNickname("KakaoUser");
+        profile .setNickname("KakaoUser");
         profile.setProfileImageUrl("http://example.com/kakao.jpg");
         account.setProfile(profile);
         kakaoUserInfo.setKakao_account(account);

--- a/src/test/java/com/team1/epilogue/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/com/team1/epilogue/auth/service/AuthServiceImplTest.java
@@ -92,7 +92,7 @@ public class AuthServiceImplTest {
 
         // Then
         assertNotNull(response);
-        assertEquals("로그인 성공", response.getMessage());
+        assertEquals("Login success", response.getMessage());
         assertEquals("jwt-token", response.getAccessToken());
         assertNotNull(response.getUser());
         assertEquals("1", response.getUser().getId());
@@ -158,7 +158,7 @@ public class AuthServiceImplTest {
 
         // Then
         assertNotNull(response);
-        assertEquals("로그인 성공", response.getMessage());
+        assertEquals("Login success", response.getMessage());
         assertEquals("jwt-google-token", response.getAccessToken());
         assertNotNull(response.getUser());
         assertEquals("2", response.getUser().getId());
@@ -202,7 +202,7 @@ public class AuthServiceImplTest {
 
         // Then
         assertNotNull(response);
-        assertEquals("로그인 성공", response.getMessage());
+        assertEquals("Login success", response.getMessage());
         assertEquals("jwt-kakao-token", response.getAccessToken());
         assertNotNull(response.getUser());
         assertEquals("3", response.getUser().getId());

--- a/src/test/java/com/team1/epilogue/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/team1/epilogue/follow/controller/FollowControllerTest.java
@@ -1,0 +1,98 @@
+package com.team1.epilogue.follow.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team1.epilogue.follow.dto.FollowActionResponse;
+import com.team1.epilogue.follow.dto.MembersResponse;
+import com.team1.epilogue.follow.dto.MessageResponse;
+import com.team1.epilogue.follow.dto.ReviewListResponse;
+import com.team1.epilogue.follow.service.FollowService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = FollowController.class)
+@DisplayName("FollowController 테스트")
+public class FollowControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockitoBean
+    private FollowService followService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @WithMockUser(username = "user1")
+    @DisplayName("팔로우 등록 API 테스트 - 성공")
+    void testFollowUser() throws Exception {
+        FollowActionResponse response = new FollowActionResponse("팔로우 생성 성공", "user1", "user2");
+        when(followService.followUser(eq("user1"), eq("user2"))).thenReturn(response);
+
+        mockMvc.perform(post("/api/follows/user2").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("팔로우 생성 성공")))
+                .andExpect(jsonPath("$.followerLoginId", is("user1")))
+                .andExpect(jsonPath("$.followedLoginId", is("user2")));
+    }
+
+    @Test
+    @WithMockUser(username = "user1")
+    @DisplayName("팔로우 삭제 API 테스트 - 성공")
+    void testUnfollowUser() throws Exception {
+        MessageResponse response = new MessageResponse("팔로우 삭제 성공");
+        Mockito.doNothing().when(followService).unfollowUser(eq("user1"), eq("user2"));
+
+        mockMvc.perform(delete("/api/follows/user2").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message", is("팔로우 삭제 성공")));
+    }
+
+    @Test
+    @WithMockUser(username = "user1")
+    @DisplayName("팔로잉 목록 조회 API 테스트 - 성공")
+    void testGetFollowList_following() throws Exception {
+        when(followService.getFollowingList(eq("user1"))).thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/follows/user1")
+                        .param("type", "following"))
+                .andExpect(status().isOk());
+    }
+
+
+    @Test
+    @WithMockUser(username = "user1")
+    @DisplayName("팔로우한 회원의 리뷰 조회 API 테스트 - 성공")
+    void testGetFollowedReviews() throws Exception {
+        ReviewListResponse response = new ReviewListResponse(Collections.emptyList(), null);
+        when(followService.getFollowedReviews(eq("user1"), anyInt(), anyInt(), anyString())).thenReturn(response);
+
+        mockMvc.perform(get("/api/follows/review")
+                        .param("page", "1")
+                        .param("limit", "10")
+                        .param("sort", "desc"))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
@@ -1,0 +1,173 @@
+package com.team1.epilogue.follow.service;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.repository.MemberRepository;
+import com.team1.epilogue.follow.dto.FollowActionResponse;
+import com.team1.epilogue.follow.dto.MemberDto;
+import com.team1.epilogue.follow.dto.PaginationDto;
+import com.team1.epilogue.follow.dto.ReviewDto;
+import com.team1.epilogue.follow.dto.ReviewListResponse;
+import com.team1.epilogue.follow.entity.Follow;
+import com.team1.epilogue.follow.repository.FollowRepository;
+import com.team1.epilogue.review.entity.Review;
+import com.team1.epilogue.review.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FollowServiceImplTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FollowRepository followRepository;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @InjectMocks
+    private FollowServiceImpl followService;
+
+    private Member follower;
+    private Member followed;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        follower = Member.builder()
+                .id(1L)
+                .loginId("user1")
+                .nickname("User One")
+                .profileUrl("http://example.com/user1.png")
+                .build();
+
+        followed = Member.builder()
+                .id(2L)
+                .loginId("user2")
+                .nickname("User Two")
+                .profileUrl("http://example.com/user2.png")
+                .build();
+    }
+
+    @Test
+    void testFollowUser_success() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        when(followRepository.findByFollowerAndFollowed(follower, followed)).thenReturn(Optional.empty());
+
+        FollowActionResponse response = followService.followUser("user1", "user2");
+
+        assertNotNull(response);
+        assertEquals("팔로우 생성 성공", response.getMessage());
+        assertEquals("user1", response.getFollowerLoginId());
+        assertEquals("user2", response.getFollowedLoginId());
+        ArgumentCaptor<Follow> followCaptor = ArgumentCaptor.forClass(Follow.class);
+        verify(followRepository).save(followCaptor.capture());
+        Follow savedFollow = followCaptor.getValue();
+        assertEquals(follower, savedFollow.getFollower());
+        assertEquals(followed, savedFollow.getFollowed());
+    }
+
+    @Test
+    void testFollowUser_alreadyFollowing() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow existingFollow = Follow.builder().id(100L).follower(follower).followed(followed).build();
+        when(followRepository.findByFollowerAndFollowed(follower, followed)).thenReturn(Optional.of(existingFollow));
+
+        Exception exception = assertThrows(RuntimeException.class, () -> {
+            followService.followUser("user1", "user2");
+        });
+        assertTrue(exception.getMessage().contains("이미 팔로우 상태입니다."));
+    }
+
+    @Test
+    void testUnfollowUser_success() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow follow = Follow.builder().id(100L).follower(follower).followed(followed).build();
+        when(followRepository.findByFollowerAndFollowed(follower, followed)).thenReturn(Optional.of(follow));
+
+        followService.unfollowUser("user1", "user2");
+
+        verify(followRepository).delete(follow);
+    }
+
+    @Test
+    void testGetFollowingList_success() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
+        when(followRepository.findByFollower(follower)).thenReturn(List.of(follow1));
+
+        List<MemberDto> followingList = followService.getFollowingList("user1");
+
+        assertEquals(1, followingList.size());
+        MemberDto dto = followingList.get(0);
+        assertEquals("user2", dto.getLoginId());
+    }
+
+    @Test
+    void testGetFollowersList_success() {
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
+        when(followRepository.findByFollowed(followed)).thenReturn(List.of(follow1));
+
+        List<MemberDto> followersList = followService.getFollowersList("user2");
+
+        assertEquals(1, followersList.size());
+        MemberDto dto = followersList.get(0);
+        assertEquals("user1", dto.getLoginId());
+    }
+
+    @Test
+    void testGetFollowedReviews_noFollowedMembers() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(followRepository.findByFollower(follower)).thenReturn(Collections.emptyList());
+
+        ReviewListResponse response = followService.getFollowedReviews("user1", 1, 10, "desc");
+
+        assertNotNull(response);
+        assertEquals(0, response.getPagination().getTotal());
+        assertTrue(response.getReview().isEmpty());
+    }
+
+    @Test
+    void testGetFollowedReviews_success() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
+        when(followRepository.findByFollower(follower)).thenReturn(List.of(follow1));
+
+        Review review = Review.builder()
+                .id(100L)
+                .member(followed)
+                .book(null)
+                .content("리뷰 내용")
+                .imageUrl("http://example.com/image.png")
+                .build();
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Page<Review> reviewPage = new PageImpl<>(List.of(review), pageable, 1);
+        when(reviewRepository.findByMemberIn(List.of(followed), pageable)).thenReturn(reviewPage);
+
+        ReviewListResponse response = followService.getFollowedReviews("user1", 1, 10, "desc");
+
+        assertNotNull(response);
+        assertEquals(1, response.getPagination().getTotal());
+        assertFalse(response.getReview().isEmpty());
+        ReviewDto dto = response.getReview().get(0);
+        assertEquals("리뷰 내용", dto.getContent());
+    }
+}

--- a/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
@@ -12,6 +12,7 @@ import com.team1.epilogue.follow.repository.FollowRepository;
 import com.team1.epilogue.review.entity.Review;
 import com.team1.epilogue.review.repository.ReviewRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -26,6 +27,8 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+
+@DisplayName("FollowServiceImpl 테스트")
 class FollowServiceImplTest {
 
     @Mock
@@ -63,6 +66,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우 생성 성공 테스트")
     void testFollowUser_success() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
@@ -82,6 +86,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("이미 팔로우 중인 경우 예외 발생 테스트")
     void testFollowUser_alreadyFollowing() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
@@ -95,6 +100,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우 삭제 성공 테스트")
     void testUnfollowUser_success() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
@@ -107,6 +113,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로잉 목록 조회 성공 테스트")
     void testGetFollowingList_success() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
@@ -120,6 +127,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우 목록 조회 성공 테스트")
     void testGetFollowersList_success() {
         when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
         Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
@@ -133,6 +141,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우한 회원이 없을 경우 리뷰 조회 테스트")
     void testGetFollowedReviews_noFollowedMembers() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         when(followRepository.findByFollower(follower)).thenReturn(Collections.emptyList());
@@ -145,6 +154,7 @@ class FollowServiceImplTest {
     }
 
     @Test
+    @DisplayName("팔로우한 회원의 리뷰 조회 성공 테스트")
     void testGetFollowedReviews_success() {
         when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
         Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();

--- a/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/team1/epilogue/follow/service/FollowServiceImplTest.java
@@ -2,6 +2,7 @@ package com.team1.epilogue.follow.service;
 
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.repository.MemberRepository;
+import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.follow.dto.FollowActionResponse;
 import com.team1.epilogue.follow.dto.MemberDto;
 import com.team1.epilogue.follow.dto.PaginationDto;
@@ -160,10 +161,18 @@ class FollowServiceImplTest {
         Follow follow1 = Follow.builder().id(1L).follower(follower).followed(followed).build();
         when(followRepository.findByFollower(follower)).thenReturn(List.of(follow1));
 
+        Book testDummyBook = Book.builder().id("챡1")
+                .title("책1")
+                .author("작가")
+                .description("설명")
+                .avgRating(4.5)
+                .coverUrl("http://example.com/cover.png")
+                .build();
+
         Review review = Review.builder()
                 .id(100L)
                 .member(followed)
-                .book(null)
+                .book(testDummyBook)
                 .content("리뷰 내용")
                 .imageUrl("http://example.com/image.png")
                 .build();


### PR DESCRIPTION
## 변경사항

- **테스트 코드 수정**
  - 기존 테스트 코드에서 불필요한 모킹 및 검증 로직을 정리하고, 인증 미비 및 정상 시의 응답 메시지와 상태 코드 검증을 명확하게 개선했습니다.
- **와일드카드 사용 변경**
  - `CustomMemberDetails` 클래스에서 `Collection<? extends GrantedAuthority>` 대신 `Collection<GrantedAuthority>`를 사용하도록 수정하여 타입 안정성을 높였습니다.
- **HashMap 형식 변경 및 ApiResponse 사용 관련**
   - 기존에 HashMap 형태로 구성된 응답 대신, 통일된 DTO 형식을 사용하여 클라이언트와의 데이터 교환을 일관성 있게 관리하고, 에러 및 성공 메시지를 명확하게 전달하기 위해 추가했습니다.
  - `ApiResponse` 클래스에 `message` 필드를 추가하고, 기존에 HashMap 형태로 구성된 응답 구조를 통일된 DTO 형식으로 변경했습니다.
---

## 리뷰 요청 사항

- 테스트 코드의 검증 로직이 의도한 대로 동작하는지, 특히 인증되지 않은 경우의 응답 메시지 및 상태 코드가 올바르게 반환되는지 확인해 주세요.
- `CustomMemberDetails`에서 와일드카드를 제거한 후 타입 안정성이 개선되었는지 리뷰해 주세요.
- `ApiResponse` 클래스에 추가된 `message` 필드가 API 응답의 일관성을 유지하고, 기존 클라이언트와의 호환성에 문제가 없는지 확인해 주세요.

---
## 관련된 이슈

- #16 
- #17 
- #18 
- #19
---
리뷰 부탁드립니다!

