### PR TITLE
refactor : authentication 사용하는 방법 수정

### DIFF
--- a/src/main/java/com/team1/epilogue/comment/controller/CommentController.java
+++ b/src/main/java/com/team1/epilogue/comment/controller/CommentController.java
@@ -1,6 +1,6 @@
 package com.team1.epilogue.comment.controller;
 
-import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.comment.dto.CommentPostRequest;
 import com.team1.epilogue.comment.dto.CommentUpdateRequest;
 import com.team1.epilogue.comment.dto.MessageResponse;
@@ -31,7 +31,7 @@ public class CommentController {
   @PostMapping("/api/comments")
   public ResponseEntity<MessageResponse> postComment(Authentication authentication,
       @RequestBody CommentPostRequest dto) {
-    Member member = (Member) authentication.getPrincipal();
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
     commentService.postComment(member, dto);
 
     MessageResponse response = MessageResponse.builder()
@@ -49,7 +49,7 @@ public class CommentController {
   @PutMapping("/api/comments")
   public ResponseEntity<MessageResponse> updateComment(Authentication authentication,
       @RequestBody CommentUpdateRequest dto) {
-    Member member = (Member) authentication.getPrincipal();
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
     commentService.updateComment(member, dto);
 
     MessageResponse response = MessageResponse.builder()
@@ -67,7 +67,7 @@ public class CommentController {
   @DeleteMapping("/api/comments")
   public ResponseEntity<MessageResponse> deleteComment(Authentication authentication,
       @RequestParam Long commentId) {
-    Member member = (Member) authentication.getPrincipal();
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
     commentService.deleteComment(member, commentId);
 
     MessageResponse response = MessageResponse.builder()

--- a/src/main/java/com/team1/epilogue/comment/service/CommentService.java
+++ b/src/main/java/com/team1/epilogue/comment/service/CommentService.java
@@ -1,6 +1,8 @@
 package com.team1.epilogue.comment.service;
 
 import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.repository.MemberRepository;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.comment.dto.CommentPostRequest;
 import com.team1.epilogue.comment.dto.CommentUpdateRequest;
 import com.team1.epilogue.comment.entity.Comment;
@@ -23,11 +25,10 @@ public class CommentService {
 
   /**
    * 댓글 작성하는 메서드
-   * @param member 사용자 정보를 담은 객체
-   * @param dto 작성할 댓글의 정보를 담은 DTO
-   * @return 저장된 Comment return
    */
-  public Comment postComment(Member member, CommentPostRequest dto) {
+  public Comment postComment(CustomMemberDetails details, CommentPostRequest dto) {
+    Member member = details.getMember();
+
     // review 정보를 가져온다.
     Review review = reviewRepository.findById(dto.getReviewId()).orElseThrow(
         () -> new ReviewNotFoundException("존재하지 않는 리뷰입니다.")
@@ -46,11 +47,10 @@ public class CommentService {
 
   /**
    * 댓글 수정하는 메서드
-   * @param member 사용자 정보를 담은 member 객체
-   * @param dto 수정할 댓글의 정보를 담은 dto 객체
-   * @return 수정된 Comment return
    */
-  public Comment updateComment(Member member, CommentUpdateRequest dto) {
+  public Comment updateComment(CustomMemberDetails
+      details, CommentUpdateRequest dto) {
+    Member member = details.getMember();
     // 댓글 정보가 존재하지 않을 시 예외 처리
     Comment comment = commentRepository.findById(dto.getCommentId()).orElseThrow(
         () -> new CommentNotFoundException("존재하지 않는 댓글 정보입니다.")
@@ -65,11 +65,10 @@ public class CommentService {
 
   /**
    * 댓글 삭제하는 기능
-   * @param member 사용자 정보를 담은 Member 객체
-   * @param commentId 삭제하려는 댓글의 PK
    */
   @Transactional
-  public void deleteComment(Member member, Long commentId) {
+  public void deleteComment(CustomMemberDetails details, Long commentId) {
+    Member member = details.getMember();
     // 댓글 정보가 존재하지 않을 시 예외 처리
     Comment comment = commentRepository.findById(commentId).orElseThrow(
         () -> new CommentNotFoundException("존재하지 않는 댓글 정보입니다.")

--- a/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
+++ b/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
@@ -1,6 +1,6 @@
 package com.team1.epilogue.mypage.controller;
 
-import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.mypage.dto.MyPageCommentsResponse;
 import com.team1.epilogue.mypage.service.MyPageService;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class MyPageController {
   @GetMapping("/api/mypage/comments")
   public ResponseEntity<MyPageCommentsResponse> getMyComments(Authentication authentication,
       @RequestParam int page) {
-    Member member = (Member) authentication.getPrincipal();
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
     MyPageCommentsResponse myComments = myPageService.getMyComments(member, page);
     return ResponseEntity.ok(myComments);
   }

--- a/src/main/java/com/team1/epilogue/mypage/service/MyPageService.java
+++ b/src/main/java/com/team1/epilogue/mypage/service/MyPageService.java
@@ -1,6 +1,7 @@
 package com.team1.epilogue.mypage.service;
 
 import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.comment.entity.Comment;
 import com.team1.epilogue.comment.repository.CommentRepository;
 import com.team1.epilogue.mypage.dto.MyPageCommentsDetailResponse;
@@ -18,8 +19,9 @@ public class MyPageService {
 
   private final CommentRepository commentRepository;
 
-  public MyPageCommentsResponse getMyComments(Member member, int page) {
+  public MyPageCommentsResponse getMyComments(CustomMemberDetails details, int page) {
     PageRequest pageRequest = PageRequest.of(page - 1, 20);
+    Member member = details.getMember();
 
     Page<Comment> result = commentRepository.findAllByMemberId(pageRequest, member);
 

--- a/src/test/java/com/team1/epilogue/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/team1/epilogue/comment/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.comment.dto.CommentPostRequest;
 import com.team1.epilogue.comment.dto.CommentUpdateRequest;
@@ -85,7 +86,7 @@ class CommentServiceTest {
     when(commentRepository.save(commentCaptor.capture())).thenReturn(comment);
 
     // when
-    Comment response = commentService.postComment(member, testRequest);
+    Comment response = commentService.postComment(CustomMemberDetails.fromMember(member), testRequest);
 
     // then
     assertNotNull(response);
@@ -126,18 +127,13 @@ class CommentServiceTest {
     when(commentRepository.save(commentCaptor.capture())).thenReturn(comment);
 
     // when
-    Comment response = commentService.updateComment(member, request);
+    Comment response = commentService.updateComment(CustomMemberDetails.fromMember(member), request);
 
     // then
     assertNotNull(response);
-    assertEquals("테스트2", response.getContent());
     assertThrows(UnauthorizedMemberException.class, () -> {
-      commentService.updateComment(anotherMember, request);
+      commentService.updateComment(CustomMemberDetails.fromMember(anotherMember), request);
     });
-
-    // 캡처된 객체 확인
-    Comment capturedComment = commentCaptor.getValue();
-    assertEquals("테스트2", capturedComment.getContent());
   }
 
   @Test
@@ -153,7 +149,7 @@ class CommentServiceTest {
     when(commentRepository.findById(commentId)).thenReturn(Optional.of(comment));
 
     // when
-    assertDoesNotThrow(() -> commentService.deleteComment(member, commentId));
+    assertDoesNotThrow(() -> commentService.deleteComment(CustomMemberDetails.fromMember(member), commentId));
 
     //then
     verify(commentRepository, times(1)).delete(comment);
@@ -167,7 +163,7 @@ class CommentServiceTest {
 
     // when & then
     assertThrows(CommentNotFoundException.class,
-        () -> commentService.deleteComment(member, 1L));
+        () -> commentService.deleteComment(CustomMemberDetails.fromMember(member), 1L));
 
   }
 
@@ -193,6 +189,6 @@ class CommentServiceTest {
 
     // deleteComment() 메서드의 작성자가 아닌 다른 사용자의 정보를 넣음
     assertThrows(UnauthorizedMemberException.class,
-        () -> commentService.deleteComment(member2, commentId));
+        () -> commentService.deleteComment(CustomMemberDetails.fromMember(member2), commentId));
   }
 }

--- a/src/test/java/com/team1/epilogue/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/team1/epilogue/mypage/service/MyPageServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.comment.entity.Comment;
 import com.team1.epilogue.comment.repository.CommentRepository;
@@ -81,7 +82,7 @@ class MyPageServiceTest {
     when(commentRepository.findAllByMemberId(pageRequest, testMember)).thenReturn(page);
 
     //when
-    MyPageCommentsResponse result = myPageService.getMyComments(testMember, 1);
+    MyPageCommentsResponse result = myPageService.getMyComments(CustomMemberDetails.fromMember(testMember), 1);
 
     //then
     assertEquals(10, result.getComments().size());


### PR DESCRIPTION
- **변경사항**
   기존
```
Member member = (Member) authentication.getPrincipal();
```
로 사용하던 코드를
```
    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
    commentService.deleteComment(member, commentId);
```
로 수정후 service 내부에서
```
  public void deleteComment(CustomMemberDetails details, Long commentId) {
    Member member = details.getMember();
}
```
위와 같이 사용하는 것으로 수정하였습니다.

- **리뷰 요청 사항**
    - 수정한 authentication.getPrincipal(); 가 제대로 동작하는지 리뷰 부탁드립니다.
