### PR TITLE
feat: 댓글 좋아요 및 취소 API 추가

### DIFF
--- a/src/main/java/com/team1/epilogue/comment/controller/CommentController.java
+++ b/src/main/java/com/team1/epilogue/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.team1.epilogue.comment.controller;
 
 import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.comment.dto.CommentPostRequest;
 import com.team1.epilogue.comment.dto.CommentUpdateRequest;
 import com.team1.epilogue.comment.dto.MessageResponse;
@@ -8,12 +9,7 @@ import com.team1.epilogue.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -72,6 +68,30 @@ public class CommentController {
 
     MessageResponse response = MessageResponse.builder()
         .message("댓글이 성공적으로 삭제되었습니다.").build();
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/api/comments/{commentId}/likes")
+  public ResponseEntity<MessageResponse> likeComment(Authentication authentication,
+                                                     @PathVariable Long commentId) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    commentService.likeComment(member, commentId);
+
+    MessageResponse response = MessageResponse.builder()
+            .message("댓글 좋아요를 성공했습니다").build();
+
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/api/comments/{commentId}/likes")
+  public ResponseEntity<MessageResponse> unlikeComment(Authentication authentication,
+                                                       @PathVariable Long commentId) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    commentService.unlikeComment(member, commentId);
+
+    MessageResponse response = MessageResponse.builder()
+            .message("댓글 좋아요 취소를 성공했습니다").build();
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/team1/epilogue/comment/entity/Comment.java
+++ b/src/main/java/com/team1/epilogue/comment/entity/Comment.java
@@ -3,11 +3,7 @@ package com.team1.epilogue.comment.entity;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.common.entity.BaseEntity;
 import com.team1.epilogue.review.entity.Review;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,4 +29,8 @@ public class Comment extends BaseEntity {
   private Review review;
 
   private String color; // 댓글 색
+
+  @Builder.Default
+  @Column(nullable = false)
+  private int likeCount = 0;
 }

--- a/src/main/java/com/team1/epilogue/comment/entity/CommentLike.java
+++ b/src/main/java/com/team1/epilogue/comment/entity/CommentLike.java
@@ -1,0 +1,32 @@
+package com.team1.epilogue.comment.entity;
+
+import com.team1.epilogue.auth.entity.Member;
+import com.team1.epilogue.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class CommentLike extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    public CommentLike(Comment comment, Member member) {
+        this.comment = comment;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/team1/epilogue/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/com/team1/epilogue/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,11 @@
+package com.team1.epilogue.comment.repository;
+
+import com.team1.epilogue.comment.entity.CommentLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    boolean existsByCommentIdAndMemberId(Long commentId, Long memberId);
+    Optional<CommentLike> findByCommentIdAndMemberId(Long commentId, Long memberId);
+}

--- a/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
@@ -2,9 +2,11 @@ package com.team1.epilogue.comment.repository;
 
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.comment.entity.Comment;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +15,11 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
   @Query("SELECT c FROM Comment c JOIN FETCH c.review r JOIN FETCH r.book WHERE c.member = :member")
   Page<Comment> findAllByMemberId(Pageable page, Member member);
 
+  @Modifying
+  @Query("UPDATE Comment c SET c.likeCount = c.likeCount + 1 WHERE c.id = :commentId")
+  int increaseLikeCount(@Param("commentId") Long commentId);
+
+  @Modifying
+  @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE c.id = :commentId AND c.likeCount > 0")
+  int decreaseLikeCount(@Param("commentId") Long commentId);
 }


### PR DESCRIPTION
## **변경사항**

### **댓글 좋아요 기능 추가**

사용자가 댓글에 좋아요를 추가하거나 취소할 수 있도록 추가했습니다

#### **✅ 추가된 API**
- `POST /comments/{commentId}/likes` → 좋아요 추가
- `DELETE /comments/{commentId}/likes` → 좋아요 취소  

### **댓글 좋아요 기능 테스트 추가**
- 사용자가 댓글 좋아요를 누르면 likeCount 증가
- 이미 좋아요한 경우 예외 발생 테스트 추가
- 좋아요 취소 시 likeCount 감소 확인
- 좋아요하지 않은 댓글 취소 시 예외 발생 검증

### **관련된 이슈**
- #37 
- Close #37 
