### PR TITLE
feat: 회원가입/정보수정시 s3 이용한 이미지 등록 및 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	testImplementation("com.squareup.okhttp3:mockwebserver:4.9.1")
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
 	implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.18.1'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.520'
 
 	// Test code Lombok 추가
 	testCompileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/team1/epilogue/auth/service/MemberService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/MemberService.java
@@ -6,7 +6,6 @@ import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.exception.*;
 import com.team1.epilogue.auth.repository.MemberRepository;
-import com.team1.epilogue.common.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -32,7 +31,7 @@ public class MemberService {
             throw new EmailAlreadyExistException();
         }
 
-        String profileUrl = request.getProfileUrl(); // 기본 이미지 URL (프론트엔드에서 기본값 지정 가능)
+        String profileUrl = request.getProfileUrl();
         if (profileImage != null && !profileImage.isEmpty()) {
             profileUrl = s3StorageService.uploadFile(profileImage);
         }

--- a/src/main/java/com/team1/epilogue/auth/service/MemberService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/MemberService.java
@@ -4,19 +4,13 @@ import com.team1.epilogue.auth.dto.RegisterRequest;
 import com.team1.epilogue.auth.dto.MemberResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
-import com.team1.epilogue.auth.exception.EmailAlreadyExistException;
-import com.team1.epilogue.auth.exception.IdAlreadyExistException;
-import com.team1.epilogue.auth.exception.InvalidBirthDateFormatException;
-import com.team1.epilogue.auth.exception.InvalidEmailFormatException;
-import com.team1.epilogue.auth.exception.InvalidPasswordException;
-import com.team1.epilogue.auth.exception.InvalidPhoneFormatException;
-import com.team1.epilogue.auth.exception.MissingRequiredFieldException;
-import com.team1.epilogue.auth.exception.NicknameAlreadyExistsException;
-import com.team1.epilogue.auth.exception.MemberNotFoundException;
+import com.team1.epilogue.auth.exception.*;
 import com.team1.epilogue.auth.repository.MemberRepository;
+import com.team1.epilogue.common.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.regex.Pattern;
@@ -27,8 +21,9 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final S3Service s3StorageService;
 
-    public MemberResponse registerMember(RegisterRequest request) {
+    public MemberResponse registerMember(RegisterRequest request, MultipartFile profileImage) {
         validateRegisterRequest(request);
         if (memberRepository.existsByLoginId(request.getLoginId())) {
             throw new IdAlreadyExistException();
@@ -36,6 +31,12 @@ public class MemberService {
         if (memberRepository.existsByEmail(request.getEmail())) {
             throw new EmailAlreadyExistException();
         }
+
+        String profileUrl = request.getProfileUrl(); // 기본 이미지 URL (프론트엔드에서 기본값 지정 가능)
+        if (profileImage != null && !profileImage.isEmpty()) {
+            profileUrl = s3StorageService.uploadFile(profileImage);
+        }
+
         Member member = Member.builder()
                 .loginId(request.getLoginId())
                 .password(passwordEncoder.encode(request.getPassword()))
@@ -44,7 +45,7 @@ public class MemberService {
                 .birthDate(LocalDate.parse(request.getBirthDate()))
                 .email(request.getEmail())
                 .phone(request.getPhone())
-                .profileUrl(request.getProfileUrl())
+                .profileUrl(profileUrl)
                 .point(0)
                 .social(null)
                 .build();
@@ -58,6 +59,44 @@ public class MemberService {
                 .email(savedMember.getEmail())
                 .phone(savedMember.getPhone())
                 .profileUrl(savedMember.getProfileUrl())
+                .build();
+    }
+
+    public MemberResponse updateMember(Long memberId, UpdateMemberRequest request, MultipartFile profileImage) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException("회원이 존재하지 않습니다."));
+        if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
+            throw new InvalidEmailFormatException();
+        }
+        memberRepository.findByEmail(request.getEmail())
+                .filter(m -> !m.getId().equals(memberId))
+                .ifPresent(m -> { throw new EmailAlreadyExistException(); });
+        memberRepository.findByNickname(request.getNickname())
+                .filter(m -> !m.getId().equals(memberId))
+                .ifPresent(m -> { throw new NicknameAlreadyExistsException(); });
+
+        member.setNickname(request.getNickname());
+        member.setEmail(request.getEmail());
+        member.setPhone(request.getPhone());
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            if (member.getProfileUrl() != null && !member.getProfileUrl().isBlank()) {
+                s3StorageService.deleteFile(member.getProfileUrl());
+            }
+            String newProfileUrl = s3StorageService.uploadFile(profileImage);
+            member.setProfileUrl(newProfileUrl);
+        }
+
+        Member updatedMember = memberRepository.save(member);
+        return MemberResponse.builder()
+                .id(String.valueOf(updatedMember.getId()))
+                .loginId(updatedMember.getLoginId())
+                .nickname(updatedMember.getNickname())
+                .name(updatedMember.getName())
+                .birthDate(updatedMember.getBirthDate().toString())
+                .email(updatedMember.getEmail())
+                .phone(updatedMember.getPhone())
+                .profileUrl(updatedMember.getProfileUrl())
                 .build();
     }
 
@@ -86,35 +125,6 @@ public class MemberService {
                 !Pattern.matches("\\d{4}-\\d{2}-\\d{2}", request.getBirthDate())) {
             throw new InvalidBirthDateFormatException();
         }
-    }
-
-    public MemberResponse updateMember(Long memberId, UpdateMemberRequest request) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException("회원이 존재하지 않습니다."));
-        if (!request.getEmail().matches("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$")) {
-            throw new InvalidEmailFormatException();
-        }
-        memberRepository.findByEmail(request.getEmail())
-                .filter(m -> !m.getId().equals(memberId))
-                .ifPresent(m -> { throw new EmailAlreadyExistException(); });
-        memberRepository.findByNickname(request.getNickname())
-                .filter(m -> !m.getId().equals(memberId))
-                .ifPresent(m -> { throw new NicknameAlreadyExistsException(); });
-        member.setNickname(request.getNickname());
-        member.setEmail(request.getEmail());
-        member.setPhone(request.getPhone());
-        member.setProfileUrl(request.getProfilePhoto());
-        Member updatedMember = memberRepository.save(member);
-        return MemberResponse.builder()
-                .id(String.valueOf(updatedMember.getId()))
-                .loginId(updatedMember.getLoginId())
-                .nickname(updatedMember.getNickname())
-                .name(updatedMember.getName())
-                .birthDate(updatedMember.getBirthDate().toString())
-                .email(updatedMember.getEmail())
-                .phone(updatedMember.getPhone())
-                .profileUrl(updatedMember.getProfileUrl())
-                .build();
     }
 
     public Member findOrCreateSocialMember(String email, String loginId, String name, String profileUrl, String socialType) {

--- a/src/main/java/com/team1/epilogue/auth/service/S3Service.java
+++ b/src/main/java/com/team1/epilogue/auth/service/S3Service.java
@@ -1,0 +1,73 @@
+package com.team1.epilogue.common.service;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.annotation.PostConstruct;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class S3Service {
+
+    private AmazonS3 s3client;
+
+    @Value("${aws.accessKey}")
+    private String awsAccessKey;
+
+    @Value("${aws.secretKey}")
+    private String awsSecretKey;
+
+    @Value("${aws.region}")
+    private String awsRegion;
+
+    @Value("${aws.s3.bucketName}")
+    private String bucketName;
+
+    @PostConstruct
+    public void init() {
+        BasicAWSCredentials creds = new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+        s3client = AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.fromName(awsRegion))
+                .withCredentials(new AWSStaticCredentialsProvider(creds))
+                .build();
+    }
+
+    public String uploadFile(MultipartFile file) {
+        File convertFile = convertMultiPartToFile(file);
+        String fileName = generateFileName(file);
+        s3client.putObject(new PutObjectRequest(bucketName, fileName, convertFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        convertFile.delete();
+        return s3client.getUrl(bucketName, fileName).toString();
+    }
+
+    public void deleteFile(String fileUrl) {
+        String fileKey = fileUrl.substring(fileUrl.lastIndexOf("/") + 1);
+        s3client.deleteObject(bucketName, fileKey);
+    }
+
+    private File convertMultiPartToFile(MultipartFile file) {
+        File convFile = new File(System.getProperty("java.io.tmpdir") + "/" + file.getOriginalFilename());
+        try (FileOutputStream fos = new FileOutputStream(convFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            throw new RuntimeException("파일 변환 실패", e);
+        }
+        return convFile;
+    }
+
+    private String generateFileName(MultipartFile file) {
+        return UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+    }
+}

--- a/src/main/java/com/team1/epilogue/auth/service/S3Service.java
+++ b/src/main/java/com/team1/epilogue/auth/service/S3Service.java
@@ -1,4 +1,4 @@
-package com.team1.epilogue.common.service;
+package com.team1.epilogue.auth.service;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;

--- a/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
@@ -7,7 +7,6 @@ import com.team1.epilogue.auth.dto.SuccessResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
-import com.team1.epilogue.auth.security.CustomUserDetailsService;
 import com.team1.epilogue.auth.service.MemberService;
 import com.team1.epilogue.auth.service.MemberWithdrawalService;
 import com.team1.epilogue.config.TestSecurityConfig;
@@ -18,11 +17,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -33,16 +33,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-/**
- * MemberController의 단위 테스트 클래스
- * - 회원 가입, 회원 탈퇴, 회원 정보 수정 기능을 테스트
- */
 @Import(TestSecurityConfig.class)
 @WebMvcTest(MemberController.class)
 @DisplayName("MemberController 테스트")
@@ -60,7 +56,6 @@ public class MemberControllerTest {
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
 
-    @MockitoBean
     private CustomMemberDetails memberDetails;
 
     @BeforeEach
@@ -87,8 +82,7 @@ public class MemberControllerTest {
     }
 
     /**
-     * 회원 가입 성공 테스트
-     * - 회원 가입 API를 호출하여 정상적으로 가입이 이루어지는지 확인
+     * 회원 가입 성공 테스트 (Multipart 요청)
      */
     @Test
     @DisplayName("회원 가입 성공 테스트")
@@ -114,12 +108,27 @@ public class MemberControllerTest {
                 .profileUrl("http://example.com/profile.jpg")
                 .build();
 
-        when(memberService.registerMember(any(RegisterRequest.class))).thenReturn(response);
+        when(memberService.registerMember(any(RegisterRequest.class), any())).thenReturn(response);
 
-        mockMvc.perform(post("/api/members/register")
-                        .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        // JSON 데이터 파트를 생성
+        MockMultipartFile dataPart = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+        // 이미지 파일 파트 (선택적, 없으면 null 전송 가능)
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "profileImage",
+                "profile.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "dummy image content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(multipart("/api/members/register")
+                        .file(dataPart)
+                        .file(imagePart)
+                        .with(csrf()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value("1"))
@@ -129,7 +138,6 @@ public class MemberControllerTest {
 
     /**
      * 회원 탈퇴 성공 테스트 (인증된 사용자)
-     * - 인증된 사용자가 정상적으로 회원 탈퇴할 수 있는지 확인
      */
     @Test
     @DisplayName("회원 탈퇴 성공 테스트")
@@ -147,8 +155,7 @@ public class MemberControllerTest {
     }
 
     /**
-     * 회원 정보 수정 성공 테스트 (인증된 사용자)
-     * - 사용자가 자신의 정보를 정상적으로 수정할 수 있는지 확인
+     * 회원 정보 수정 성공 테스트 (인증된 사용자, Multipart 요청)
      */
     @Test
     @DisplayName("회원 정보 수정 성공 테스트")
@@ -170,13 +177,27 @@ public class MemberControllerTest {
                 .profileUrl("http://example.com/newProfile.jpg")
                 .build();
 
-        when(memberService.updateMember(anyLong(), any(UpdateMemberRequest.class))).thenReturn(response);
+        when(memberService.updateMember(anyLong(), any(UpdateMemberRequest.class), any())).thenReturn(response);
 
-        mockMvc.perform(put("/api/members")
+        MockMultipartFile dataPart = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "profileImage",
+                "newProfile.jpg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "new dummy image content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        mockMvc.perform(multipart("/api/members")
+                        .file(dataPart)
+                        .file(imagePart)
                         .with(csrf())
                         .with(user(memberDetails))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .with(request -> { request.setMethod("PUT"); return request; }))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value("1"))
@@ -188,7 +209,6 @@ public class MemberControllerTest {
 
     /**
      * 회원 탈퇴 실패 테스트 - 인증되지 않은 사용자
-     * - 인증되지 않은 사용자가 탈퇴 요청을 보낼 경우 실패하는지 확인
      */
     @Test
     @DisplayName("회원 탈퇴 실패 - 인증되지 않은 사용자")
@@ -196,13 +216,11 @@ public class MemberControllerTest {
         mockMvc.perform(delete("/api/members")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.메시지").value("인증되지 않은 사용자"));
+                .andExpect(jsonPath("$.message").value("Unauthorized user"));
     }
-
 
     /**
      * 회원 정보 수정 실패 테스트 - 인증되지 않은 사용자
-     * - 인증되지 않은 사용자가 정보 수정 요청을 보낼 경우 실패하는지 확인
      */
     @Test
     @DisplayName("회원 정보 수정 실패 - 인증되지 않은 사용자")
@@ -212,11 +230,19 @@ public class MemberControllerTest {
         request.setEmail("fail@example.com");
         request.setPhone("010-0000-0000");
         request.setProfilePhoto("http://example.com/fail.jpg");
-        mockMvc.perform(put("/api/members")
+
+        MockMultipartFile dataPart = new MockMultipartFile(
+                "data",
+                "",
+                MediaType.APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        mockMvc.perform(multipart("/api/members")
+                        .file(dataPart)
                         .with(csrf())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .with(request -> { request.setMethod("PUT"); return request; }))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.메시지").value("인증되지 않은 사용자"));
+                .andExpect(jsonPath("$.message").value("Unauthorized"));
     }
 }

--- a/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
@@ -33,8 +33,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -56,6 +56,7 @@ public class MemberControllerTest {
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
 
+    @MockitoBean
     private CustomMemberDetails memberDetails;
 
     @BeforeEach
@@ -197,7 +198,7 @@ public class MemberControllerTest {
                         .file(imagePart)
                         .with(csrf())
                         .with(user(memberDetails))
-                        .with(request -> { request.setMethod("PUT"); return request; }))
+                        .with(req -> { req.setMethod("PUT"); return req; }))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value("1"))
@@ -241,8 +242,8 @@ public class MemberControllerTest {
         mockMvc.perform(multipart("/api/members")
                         .file(dataPart)
                         .with(csrf())
-                        .with(request -> { request.setMethod("PUT"); return request; }))
+                        .with(req -> { req.setMethod("PUT"); return req; }))
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.message").value("Unauthorized"));
+                .andExpect(jsonPath("$.message").value("Unauthorized user"));
     }
 }

--- a/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
+++ b/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
@@ -20,10 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-/**
- * [클래스 레벨]
- * MemberService에 대한 단위 테스트 클래스.
- */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MemberService 테스트")
 public class MemberServiceTest {
@@ -39,10 +35,6 @@ public class MemberServiceTest {
 
     private RegisterRequest registerRequest;
 
-    /**
-     * [설정 메서드]
-     * 각 테스트 실행 전, 기본 데이터를 초기화하는 메서드.
-     */
     @BeforeEach
     public void setup() {
         registerRequest = new RegisterRequest();
@@ -56,10 +48,6 @@ public class MemberServiceTest {
         registerRequest.setProfileUrl("http://example.com/photo.jpg");
     }
 
-    /**
-     * [테스트 메서드]
-     * 회원 가입 성공 테스트.
-     */
     @Test
     @DisplayName("정상 회원 등록 테스트")
     public void testRegisterMemberSuccess() {
@@ -82,42 +70,33 @@ public class MemberServiceTest {
                 .build()
         );
 
-        MemberResponse response = memberService.registerMember(registerRequest);
+        // MultipartFile이 없으므로 null 전달
+        MemberResponse response = memberService.registerMember(registerRequest, null);
 
         assertNotNull(response);
         assertEquals("serviceMember", response.getLoginId());
         verify(memberRepository, times(1)).save(any(Member.class));
     }
 
-    /**
-     * [테스트 메서드]
-     * 중복된 로그인 ID가 존재하는 경우 회원가입 실패 테스트.
-     */
     @Test
     @DisplayName("중복 로그인 ID 테스트")
     public void testDuplicateMemberId() {
         when(memberRepository.existsByLoginId("serviceMember")).thenReturn(true);
 
-        assertThrows(IdAlreadyExistException.class, () -> memberService.registerMember(registerRequest));
+        // MultipartFile 인자는 null로 전달
+        assertThrows(IdAlreadyExistException.class, () -> memberService.registerMember(registerRequest, null));
     }
 
-    /**
-     * [테스트 메서드]
-     * 중복된 이메일이 존재하는 경우 회원가입 실패 테스트.
-     */
     @Test
     @DisplayName("중복 이메일 테스트")
     public void testDuplicateEmail() {
         when(memberRepository.existsByLoginId("serviceMember")).thenReturn(false);
         when(memberRepository.existsByEmail("service@example.com")).thenReturn(true);
 
-        assertThrows(EmailAlreadyExistException.class, () -> memberService.registerMember(registerRequest));
+        // MultipartFile 인자는 null로 전달
+        assertThrows(EmailAlreadyExistException.class, () -> memberService.registerMember(registerRequest, null));
     }
 
-    /**
-     * [테스트 메서드]
-     * 회원 정보 수정 성공 테스트.
-     */
     @Test
     @DisplayName("정상 회원 정보 수정 테스트")
     public void testUpdateMemberSuccess() {
@@ -144,17 +123,14 @@ public class MemberServiceTest {
         when(memberRepository.findById(1L)).thenReturn(Optional.of(existingMember));
         when(memberRepository.save(any(Member.class))).thenReturn(existingMember);
 
-        MemberResponse response = memberService.updateMember(1L, updateRequest);
+        // MultipartFile 인자는 null로 전달
+        MemberResponse response = memberService.updateMember(1L, updateRequest, null);
 
         assertNotNull(response);
         assertEquals("updatedNick", response.getNickname());
         assertEquals("updated@example.com", response.getEmail());
     }
 
-    /**
-     * [테스트 메서드]
-     * 존재하지 않는 회원을 수정하려고 할 때 실패 테스트.
-     */
     @Test
     @DisplayName("회원 정보 수정 - 회원이 존재하지 않을 경우")
     public void testUpdateMemberNotFound() {
@@ -164,6 +140,7 @@ public class MemberServiceTest {
 
         when(memberRepository.findById(1L)).thenReturn(Optional.empty());
 
-        assertThrows(MemberNotFoundException.class, () -> memberService.updateMember(1L, updateRequest));
+        // MultipartFile 인자는 null로 전달
+        assertThrows(MemberNotFoundException.class, () -> memberService.updateMember(1L, updateRequest, null));
     }
 }

--- a/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
+++ b/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
@@ -54,7 +54,6 @@ public class MemberServiceTest {
         when(memberRepository.existsByLoginId("serviceMember")).thenReturn(false);
         when(memberRepository.existsByEmail("service@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("encodedPassword123");
-
         when(memberRepository.save(any(Member.class))).thenReturn(Member.builder()
                 .id(1L)
                 .loginId(registerRequest.getLoginId())
@@ -70,7 +69,6 @@ public class MemberServiceTest {
                 .build()
         );
 
-        // MultipartFile이 없으므로 null 전달
         MemberResponse response = memberService.registerMember(registerRequest, null);
 
         assertNotNull(response);

--- a/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
+++ b/src/test/java/com/team1/epilogue/auth/service/MemberServiceTest.java
@@ -83,7 +83,6 @@ public class MemberServiceTest {
     public void testDuplicateMemberId() {
         when(memberRepository.existsByLoginId("serviceMember")).thenReturn(true);
 
-        // MultipartFile 인자는 null로 전달
         assertThrows(IdAlreadyExistException.class, () -> memberService.registerMember(registerRequest, null));
     }
 
@@ -93,7 +92,6 @@ public class MemberServiceTest {
         when(memberRepository.existsByLoginId("serviceMember")).thenReturn(false);
         when(memberRepository.existsByEmail("service@example.com")).thenReturn(true);
 
-        // MultipartFile 인자는 null로 전달
         assertThrows(EmailAlreadyExistException.class, () -> memberService.registerMember(registerRequest, null));
     }
 
@@ -123,7 +121,6 @@ public class MemberServiceTest {
         when(memberRepository.findById(1L)).thenReturn(Optional.of(existingMember));
         when(memberRepository.save(any(Member.class))).thenReturn(existingMember);
 
-        // MultipartFile 인자는 null로 전달
         MemberResponse response = memberService.updateMember(1L, updateRequest, null);
 
         assertNotNull(response);
@@ -140,7 +137,6 @@ public class MemberServiceTest {
 
         when(memberRepository.findById(1L)).thenReturn(Optional.empty());
 
-        // MultipartFile 인자는 null로 전달
         assertThrows(MemberNotFoundException.class, () -> memberService.updateMember(1L, updateRequest, null));
     }
 }


### PR DESCRIPTION
## 변경사항

- **S3 파일 업로드 및 삭제**  
  - S3Service 클래스를 추가하여, 프로필 이미지 파일을 S3에 업로드하도록 구현했습니다.
  - MultipartFile을 임시 파일로 변환하고, UUID를 기반으로 고유한 파일 이름을 생성하여 S3에 업로드 후 PublicRead 권한을 부여합니다.
  - 업로드된 파일의 URL을 반환하고, 삭제 요청 시 URL에서 파일 키를 추출하여 S3에서 삭제하는 기능을 구현했습니다.

- **회원 가입 및 정보 수정 시 프로필 이미지 처리**  
  - MemberService 클래스에서 회원 가입 시 전달된 프로필 이미지가 존재하면, S3Service를 이용해 이미지를 S3에 업로드하고 해당 URL을 회원의 프로필 URL로 저장하도록 변경했습니다.
  - 회원 정보 수정 시에도, 새 프로필 이미지가 제공되면 기존 이미지가 있으면 S3에서 삭제한 후 새 이미지를 업로드하는 로직을 추가했습니다.
---

## 리뷰 요청 사항

- S3Service의 파일 변환, UUID 기반 파일 이름 생성, 파일 업로드 및 삭제 로직에 대한 리뷰 부탁드립니다. 
- MemberService의 프로필 이미지 처리 로직(회원 가입 및 정보 수정 시 S3 연동 부분)의 예외 처리가 잘 되어있는지 확인 부탁드립니다.

---
## 관련된 이슈 / 참고 링크
- #20

---
리뷰 부탁드립니다!
