### PR TITLE
feat: 리뷰 최신순 조회 API 추가 및 이미지 업로드

### DIFF
--- a/src/main/java/com/team1/epilogue/auth/repository/CustomMemberRepositoryImpl.java
+++ b/src/main/java/com/team1/epilogue/auth/repository/CustomMemberRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.entity.QMember;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -15,7 +14,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class CustomBookRepositoryImpl implements CustomMemberRepository{
+public class CustomMemberRepositoryImpl implements CustomMemberRepository{
 
   private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/com/team1/epilogue/book/service/BookService.java
+++ b/src/main/java/com/team1/epilogue/book/service/BookService.java
@@ -103,7 +103,7 @@ public class BookService {
         data -> {
           if (data.getId() != book.getId()) { // 같은 작가의 현재 가져온 책을 제외한 다른 책들을 가져온다.
             dtoList.add(
-                SameAuthorBookTitleIsbn.builder().title(data.getTitle()).id(data.getId()).build());
+                SameAuthorBookTitleIsbn.builder().title(data.getTitle()).isbn(data.getId()).build());
           }
         }
     );

--- a/src/main/java/com/team1/epilogue/comment/service/CommentService.java
+++ b/src/main/java/com/team1/epilogue/comment/service/CommentService.java
@@ -41,6 +41,7 @@ public class CommentService {
   /**
    * 댓글 작성하는 메서드
    */
+  @Transactional
   public Comment postComment(CustomMemberDetails details, CommentPostRequest dto) {
     Member member = memberRepository.findById(details.getId())
             .orElseThrow(() -> new MemberNotFoundException("ID가 " + details.getId() + "인 회원을 찾을 수 없습니다."));

--- a/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
+++ b/src/main/java/com/team1/epilogue/follow/dto/ReviewDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Setter
@@ -15,7 +16,7 @@ public class ReviewDto {
     private String id;
     private String bookId;
     private String content;
-    private String imageUrl;
+    private List<String> imageUrls;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
     private MemberDto member;

--- a/src/main/java/com/team1/epilogue/follow/service/FollowService.java
+++ b/src/main/java/com/team1/epilogue/follow/service/FollowService.java
@@ -162,7 +162,7 @@ public class FollowService {
                 .id(String.valueOf(review.getId()))
                 .bookId(review.getBook() != null ? String.valueOf(review.getBook().getId()) : null)
                 .content(review.getContent())
-                .imageUrl(review.getImageUrl())
+                .imageUrls(review.getImageUrls())
                 .createdAt(review.getCreatedAt())
                 .member(convertToMemberDto(review.getMember()))
                 .build();

--- a/src/main/java/com/team1/epilogue/rating/controller/RatingController.java
+++ b/src/main/java/com/team1/epilogue/rating/controller/RatingController.java
@@ -8,66 +8,72 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class RatingController {
 
-    private final RatingService ratingService;
+  private final RatingService ratingService;
 
-    /**
-     * 책에 대한 별점을 생성하거나 수정합니다
-     *
-     * @param bookId           별점을 남길 책의 ID
-     * @param ratingRequestDto 클라이언트가 전달한 별점 데이터
-     * @param authentication   현재 인증된 사용자
-     * @return 생성된 별점의 상세 정보를 담은 DTO
-     */
-    @PostMapping("/books/{bookId}/ratings")
-    public ResponseEntity<RatingResponseDto> createRating(@PathVariable String bookId,
-                                                          @RequestBody @Valid RatingRequestDto ratingRequestDto,
-                                                          Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        RatingResponseDto ratingResponseDto =
-                ratingService.createRating(bookId, ratingRequestDto, member);
+  /**
+   * 책에 대한 별점을 생성하거나 수정합니다
+   *
+   * @param bookId           별점을 남길 책의 ID
+   * @param ratingRequestDto 클라이언트가 전달한 별점 데이터
+   * @param authentication   현재 인증된 사용자
+   * @return 생성된 별점의 상세 정보를 담은 DTO
+   */
+  @PostMapping("/books/{bookId}/ratings")
+  public ResponseEntity<RatingResponseDto> createRating(@PathVariable String bookId,
+      @RequestBody @Valid RatingRequestDto ratingRequestDto,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    RatingResponseDto ratingResponseDto =
+        ratingService.createRating(bookId, ratingRequestDto, member);
 
-        return ResponseEntity.ok().body(ratingResponseDto);
-    }
+    return ResponseEntity.ok().body(ratingResponseDto);
+  }
 
-    /**
-     * 책에 대한 별점을 수정합니다
-     *
-     * @param bookId           별점을 수정할 책의 ID
-     * @param ratingRequestDto 클라이언트가 전달한 수정된 별점 데이터
-     * @param authentication   현재 인증된 사용자
-     * @return 수정된 별점의 상세 정보를 담은 DTO
-     */
-    @PutMapping("/books/{bookId}/ratings")
-    public ResponseEntity<RatingResponseDto> updateRating(@PathVariable String bookId,
-                                                          @RequestBody RatingRequestDto ratingRequestDto,
-                                                          Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        RatingResponseDto ratingResponseDto =
-                ratingService.updateRating(bookId, ratingRequestDto, member);
+  /**
+   * 책에 대한 별점을 수정합니다
+   *
+   * @param bookId           별점을 수정할 책의 ID
+   * @param ratingRequestDto 클라이언트가 전달한 수정된 별점 데이터
+   * @param authentication   현재 인증된 사용자
+   * @return 수정된 별점의 상세 정보를 담은 DTO
+   */
+  @PutMapping("/books/{bookId}/ratings")
+  public ResponseEntity<RatingResponseDto> updateRating(@PathVariable String bookId,
+      @RequestBody RatingRequestDto ratingRequestDto,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    RatingResponseDto ratingResponseDto =
+        ratingService.updateRating(bookId, ratingRequestDto, member);
 
-        return ResponseEntity.ok().body(ratingResponseDto);
-    }
+    return ResponseEntity.ok().body(ratingResponseDto);
+  }
 
-    /**
-     * 책에 대한 별점을 삭제합니다
-     *
-     * @param bookId         별점을 삭제할 책의 ID
-     * @param authentication 현재 인증된 사용자
-     * @return 삭제 완료 메시지
-     */
-    @DeleteMapping("/books/{bookId}/ratings")
-    public ResponseEntity<String> deleteRating(@PathVariable String bookId,
-                                               Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        ratingService.deleteRating(bookId, member);
+  /**
+   * 책에 대한 별점을 삭제합니다
+   *
+   * @param bookId         별점을 삭제할 책의 ID
+   * @param authentication 현재 인증된 사용자
+   * @return 삭제 완료 메시지
+   */
+  @DeleteMapping("/books/{bookId}/ratings")
+  public ResponseEntity<String> deleteRating(@PathVariable String bookId,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    ratingService.deleteRating(bookId, member);
 
-        return ResponseEntity.ok().body("별점이 성공적으로 삭제되었습니다.");
-    }
+    return ResponseEntity.ok().body("별점이 성공적으로 삭제되었습니다.");
+  }
 }

--- a/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
+++ b/src/main/java/com/team1/epilogue/rating/dto/RatingRequestDto.java
@@ -16,15 +16,15 @@ import lombok.NoArgsConstructor;
 @Builder
 public class RatingRequestDto {
 
-    @DecimalMin("0.5")
-    @DecimalMax("5")
-    private Double score;  // 0.5 ~ 5 사이의 점수를 받습니다
+  @DecimalMin("0.5")
+  @DecimalMax("5")
+  private Double score;  // 0.5 ~ 5 사이의 점수를 받습니다
 
-    public Rating toEntity(Book book, Member member) {
-        return Rating.builder()
-                .score(score)
-                .book(book)
-                .member(member)
-                .build();
-    }
+  public Rating toEntity(Book book, Member member) {
+    return Rating.builder()
+        .score(score)
+        .book(book)
+        .member(member)
+        .build();
+  }
 }

--- a/src/main/java/com/team1/epilogue/rating/dto/RatingResponseDto.java
+++ b/src/main/java/com/team1/epilogue/rating/dto/RatingResponseDto.java
@@ -1,28 +1,29 @@
 package com.team1.epilogue.rating.dto;
 
 import com.team1.epilogue.rating.entity.Rating;
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
 public class RatingResponseDto {
-    private Long id;            // 별점 ID
-    private String bookId;      // 책 ID
-    private Long memberId;      // 사용자 ID
-    private Double score;       // 별점
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
 
-    public static RatingResponseDto from(Rating rating) {
-        return RatingResponseDto.builder()
-                .id(rating.getId())
-                .bookId(rating.getBook().getId())
-                .memberId(rating.getMember().getId())
-                .score(rating.getScore())
-                .createdAt(rating.getCreatedAt())
-                .modifiedAt(rating.getModifiedAt())
-                .build();
-    }
+  private Long id;            // 별점 ID
+  private String bookId;      // 책 ID
+  private Long memberId;      // 사용자 ID
+  private Double score;       // 별점
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static RatingResponseDto from(Rating rating) {
+    return RatingResponseDto.builder()
+        .id(rating.getId())
+        .bookId(rating.getBook().getId())
+        .memberId(rating.getMember().getId())
+        .score(rating.getScore())
+        .createdAt(rating.getCreatedAt())
+        .modifiedAt(rating.getModifiedAt())
+        .build();
+  }
 }

--- a/src/main/java/com/team1/epilogue/rating/entity/Rating.java
+++ b/src/main/java/com/team1/epilogue/rating/entity/Rating.java
@@ -3,7 +3,14 @@ package com.team1.epilogue.rating.entity;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.common.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,26 +26,26 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class Rating extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;    // 별점 ID
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;    // 별점 ID
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id", nullable = false)
-    private Book book;  // 해당 별점이 속한 책
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "book_id", nullable = false)
+  private Book book;  // 해당 별점이 속한 책
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;  // 별점을 작성한 사용자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;  // 별점을 작성한 사용자
 
-    private Double score;   // 별점 (0.5 ~ 5)
+  private Double score;   // 별점 (0.5 ~ 5)
 
-    /**
-     * 별점을 업데이트합니다
-     *
-     * @param score 새로운 별점
-     */
-    public void updateScore(Double score) {
-        this.score = score;
-    }
+  /**
+   * 별점을 업데이트합니다
+   *
+   * @param score 새로운 별점
+   */
+  public void updateScore(Double score) {
+    this.score = score;
+  }
 }

--- a/src/main/java/com/team1/epilogue/rating/exception/RatingNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/rating/exception/RatingNotFoundException.java
@@ -2,7 +2,7 @@ package com.team1.epilogue.rating.exception;
 
 public class RatingNotFoundException extends RuntimeException {
 
-    public RatingNotFoundException(String message) {
-        super(message);
-    }
+  public RatingNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/rating/repository/RatingRepository.java
+++ b/src/main/java/com/team1/epilogue/rating/repository/RatingRepository.java
@@ -2,22 +2,22 @@ package com.team1.epilogue.rating.repository;
 
 import com.team1.epilogue.rating.entity.Rating;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import java.util.Optional;
 
 public interface RatingRepository extends JpaRepository<Rating, Long> {
 
-    /**
-     * 특정 책에 대해 특정 사용자가 작성한 별점을 조회합니다
-     *
-     * @param memberId 책에 별점을 남긴 사용자의 ID
-     * @param bookId   해당 책의 ID
-     * @return 해당 책에 사용자가 남긴 별점 정보가 담긴 Optional 객체
-     */
-    Optional<Rating> findByMemberIdAndBookId(Long memberId, String bookId);
+  /**
+   * 특정 책에 대해 특정 사용자가 작성한 별점을 조회합니다
+   *
+   * @param memberId 책에 별점을 남긴 사용자의 ID
+   * @param bookId   해당 책의 ID
+   * @return 해당 책에 사용자가 남긴 별점 정보가 담긴 Optional 객체
+   */
+  Optional<Rating> findByMemberIdAndBookId(Long memberId, String bookId);
 
-    // 해당 책의 평균 별점 계산 (별점이 없으면 0 반환)
-    @Query("SELECT COALESCE(AVG(r.score), 0) FROM Rating r WHERE r.book.id = :bookId")
-    Double findAverageRatingByBookId(@Param("bookId") String bookId);
+  // 해당 책의 평균 별점 계산 (별점이 없으면 0 반환)
+  @Query("SELECT COALESCE(AVG(r.score), 0) FROM Rating r WHERE r.book.id = :bookId")
+  Double findAverageRatingByBookId(@Param("bookId") String bookId);
 }

--- a/src/main/java/com/team1/epilogue/rating/service/RatingService.java
+++ b/src/main/java/com/team1/epilogue/rating/service/RatingService.java
@@ -20,60 +20,65 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RatingService {
 
-    private final RatingRepository ratingRepository;
-    private final BookRepository bookRepository;
-    private final MemberRepository memberRepository;
+  private final RatingRepository ratingRepository;
+  private final BookRepository bookRepository;
+  private final MemberRepository memberRepository;
 
-    @Transactional
-    public RatingResponseDto createRating(String bookId, RatingRequestDto ratingRequestDto, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
+  @Transactional
+  public RatingResponseDto createRating(String bookId, RatingRequestDto ratingRequestDto,
+      CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Book book = bookRepository.findById(bookId)
+        .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
 
-        if (ratingRepository.findByMemberIdAndBookId(member.getId(), bookId).isPresent()) {
-            throw new IllegalArgumentException("이미 별점을 남겼습니다. 수정하려면 PUT 요청을 사용하세요");
-        }
-
-        Rating rating = ratingRequestDto.toEntity(book, member);
-        Rating savedRating = ratingRepository.save(rating);
-
-        updateBookRating(bookId);
-
-        return RatingResponseDto.from(savedRating);
+    if (ratingRepository.findByMemberIdAndBookId(member.getId(), bookId).isPresent()) {
+      throw new IllegalArgumentException("이미 별점을 남겼습니다. 수정하려면 PUT 요청을 사용하세요");
     }
 
-    @Transactional
-    public RatingResponseDto updateRating(String bookId, RatingRequestDto ratingRequestDto, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
-                .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
+    Rating rating = ratingRequestDto.toEntity(book, member);
+    Rating savedRating = ratingRepository.save(rating);
 
-        rating.updateScore(ratingRequestDto.getScore());
-        updateBookRating(bookId);
+    updateBookRating(bookId);
 
-        return RatingResponseDto.from(rating);
-    }
+    return RatingResponseDto.from(savedRating);
+  }
 
-    @Transactional
-    public void deleteRating(String bookId, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
-                .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
+  @Transactional
+  public RatingResponseDto updateRating(String bookId, RatingRequestDto ratingRequestDto,
+      CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
+        .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
 
-        ratingRepository.delete(rating);
-        updateBookRating(bookId);
-    }
+    rating.updateScore(ratingRequestDto.getScore());
+    updateBookRating(bookId);
 
-    @Transactional
-    public void updateBookRating(String bookId) {
-        Double avgRating = ratingRepository.findAverageRatingByBookId(bookId);
-        Book book = bookRepository.findByIdWithLock(bookId)
-                .orElseThrow(() -> new BookNotFoundException("책을 찾을 수 없습니다."));
+    return RatingResponseDto.from(rating);
+  }
 
-        book.updateAvgRating(avgRating != null ? avgRating : 0.0);
-        bookRepository.save(book);
-    }
+  @Transactional
+  public void deleteRating(String bookId, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Rating rating = ratingRepository.findByMemberIdAndBookId(member.getId(), bookId)
+        .orElseThrow(() -> new RatingNotFoundException("해당 책에 대한 별점이 존재하지 않습니다."));
+
+    ratingRepository.delete(rating);
+    updateBookRating(bookId);
+  }
+
+  @Transactional
+  public void updateBookRating(String bookId) {
+    Double avgRating = ratingRepository.findAverageRatingByBookId(bookId);
+    Book book = bookRepository.findByIdWithLock(bookId)
+        .orElseThrow(() -> new BookNotFoundException("책을 찾을 수 없습니다."));
+
+    book.updateAvgRating(avgRating != null ? avgRating : 0.0);
+    bookRepository.save(book);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -6,9 +6,12 @@ import com.team1.epilogue.review.dto.ReviewResponseDto;
 import com.team1.epilogue.review.service.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,13 +28,16 @@ public class ReviewController {
      * @param authentication   현재 인증된 사용자
      * @return 생성된 리뷰의 상세 정보를 담은 DTO
      */
-    @PostMapping("/books/{bookId}/reviews")
-    public ResponseEntity<ReviewResponseDto> createReview(@PathVariable String bookId,
-                                                          @RequestBody ReviewRequestDto reviewRequestDto,
-                                                          Authentication authentication) {
+    @PostMapping(value = "/books/{bookId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ReviewResponseDto> createReview(
+            @PathVariable String bookId,
+            @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            Authentication authentication
+    ) {
         CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
         ReviewResponseDto reviewResponseDto =
-                reviewService.createReview(bookId, reviewRequestDto, member);
+                reviewService.createReview(bookId, reviewRequestDto, images, member);
 
         return ResponseEntity.ok(reviewResponseDto);
     }
@@ -89,12 +95,15 @@ public class ReviewController {
      * @param authentication   현재 인증된 사용자
      * @return 수정된 리뷰의 상세 정보를 담은 DTO
      */
-    @PutMapping("/reviews/{reviewId}")
-    public ResponseEntity<ReviewResponseDto> updateReview(@PathVariable Long reviewId,
-                                                          @RequestBody ReviewRequestDto reviewRequestDto,
-                                                          Authentication authentication) {
+    @PutMapping(value = "/reviews/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ReviewResponseDto> updateReview(
+            @PathVariable Long reviewId,
+            @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            Authentication authentication
+    ) {
         CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        ReviewResponseDto updatedReview = reviewService.updateReview(reviewId, reviewRequestDto, member);
+        ReviewResponseDto updatedReview = reviewService.updateReview(reviewId, reviewRequestDto, images, member);
 
         return ResponseEntity.ok(updatedReview);
     }

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -72,6 +72,15 @@ public class ReviewController {
         return ResponseEntity.ok(reviewResponseDto);
     }
 
+    @GetMapping("/reviews/latest")
+    public ResponseEntity<Page<ReviewResponseDto>> getLatestReviews(
+            @RequestParam("page") int page,
+            @RequestParam("size") int size
+    ) {
+        Page<ReviewResponseDto> reviews = reviewService.getLatestReviews(page, size);
+        return ResponseEntity.ok(reviews);
+    }
+
     /**
      * 특정 리뷰를 수정합니다
      *

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -4,152 +4,161 @@ import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.review.dto.ReviewRequestDto;
 import com.team1.epilogue.review.dto.ReviewResponseDto;
 import com.team1.epilogue.review.service.ReviewService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class ReviewController {
 
-    private final ReviewService reviewService;
+  private final ReviewService reviewService;
 
-    /**
-     * 특정 책에 대한 리뷰를 생성합니다
-     *
-     * @param bookId           리뷰를 작성할 책의 ID
-     * @param reviewRequestDto 클라이언트가 전달한 리뷰 데이터
-     * @param authentication   현재 인증된 사용자
-     * @return 생성된 리뷰의 상세 정보를 담은 DTO
-     */
-    @PostMapping(value = "/books/{bookId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ReviewResponseDto> createReview(
-            @PathVariable String bookId,
-            @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
-            Authentication authentication
-    ) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        ReviewResponseDto reviewResponseDto =
-                reviewService.createReview(bookId, reviewRequestDto, images, member);
+  /**
+   * 특정 책에 대한 리뷰를 생성합니다
+   *
+   * @param bookId           리뷰를 작성할 책의 ID
+   * @param reviewRequestDto 클라이언트가 전달한 리뷰 데이터
+   * @param authentication   현재 인증된 사용자
+   * @return 생성된 리뷰의 상세 정보를 담은 DTO
+   */
+  @PostMapping(value = "/books/{bookId}/reviews", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ReviewResponseDto> createReview(
+      @PathVariable String bookId,
+      @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
+      @RequestPart(value = "images", required = false) List<MultipartFile> images,
+      Authentication authentication
+  ) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    ReviewResponseDto reviewResponseDto =
+        reviewService.createReview(bookId, reviewRequestDto, images, member);
 
-        return ResponseEntity.ok(reviewResponseDto);
-    }
+    return ResponseEntity.ok(reviewResponseDto);
+  }
 
-    /**
-     * 특정 책의 모든 리뷰를 페이징하여 조회합니다
-     * - 기본 정렬: 좋아요순 (likeCount DESC)
-     * - 정렬 방식 선택 가능: 최신순 (latest), 좋아요순 (likes)
-     *
-     * @param bookId   조회할 책의 ID
-     * @param page     조회할 페이지 번호 (1부터 시작)
-     * @param size     한 페이지당 조회할 리뷰 개수
-     * @param sortType 정렬 기준 ("likes"=좋아요순, "latest"=최신순, 기본값: "likes")
-     * @return 해당 책의 리뷰 목록을 담은 페이징된 DTO 리스트
-     */
-    @GetMapping("/books/{bookId}/reviews")
-    public ResponseEntity<Page<ReviewResponseDto>> getReviews(
-            @PathVariable String bookId,
-            @RequestParam("page") int page,
-            @RequestParam("size") int size,
-            @RequestParam(value = "sortType", defaultValue = "likes") String sortType
-    ) {
-        Page<ReviewResponseDto> reviews = reviewService.getReviews(bookId, page, size, sortType);
+  /**
+   * 특정 책의 모든 리뷰를 페이징하여 조회합니다 - 기본 정렬: 좋아요순 (likeCount DESC) - 정렬 방식 선택 가능: 최신순 (latest), 좋아요순
+   * (likes)
+   *
+   * @param bookId   조회할 책의 ID
+   * @param page     조회할 페이지 번호 (1부터 시작)
+   * @param size     한 페이지당 조회할 리뷰 개수
+   * @param sortType 정렬 기준 ("likes"=좋아요순, "latest"=최신순, 기본값: "likes")
+   * @return 해당 책의 리뷰 목록을 담은 페이징된 DTO 리스트
+   */
+  @GetMapping("/books/{bookId}/reviews")
+  public ResponseEntity<Page<ReviewResponseDto>> getReviews(
+      @PathVariable String bookId,
+      @RequestParam("page") int page,
+      @RequestParam("size") int size,
+      @RequestParam(value = "sortType", defaultValue = "likes") String sortType
+  ) {
+    Page<ReviewResponseDto> reviews = reviewService.getReviews(bookId, page, size, sortType);
 
-        return ResponseEntity.ok(reviews);
-    }
+    return ResponseEntity.ok(reviews);
+  }
 
-    /**
-     * 특정 리뷰의 상세 정보를 조회합니다
-     *
-     * @param reviewId 조회할 리뷰의 ID
-     * @return 해당 리뷰의 상세 정보를 담은 DTO
-     */
-    @GetMapping("/reviews/{reviewId}")
-    public ResponseEntity<ReviewResponseDto> getReviewDetail(@PathVariable Long reviewId) {
-        ReviewResponseDto reviewResponseDto = reviewService.getReviewDetail(reviewId);
+  /**
+   * 특정 리뷰의 상세 정보를 조회합니다
+   *
+   * @param reviewId 조회할 리뷰의 ID
+   * @return 해당 리뷰의 상세 정보를 담은 DTO
+   */
+  @GetMapping("/reviews/{reviewId}")
+  public ResponseEntity<ReviewResponseDto> getReviewDetail(@PathVariable Long reviewId) {
+    ReviewResponseDto reviewResponseDto = reviewService.getReviewDetail(reviewId);
 
-        return ResponseEntity.ok(reviewResponseDto);
-    }
+    return ResponseEntity.ok(reviewResponseDto);
+  }
 
-    @GetMapping("/reviews/latest")
-    public ResponseEntity<Page<ReviewResponseDto>> getLatestReviews(
-            @RequestParam("page") int page,
-            @RequestParam("size") int size
-    ) {
-        Page<ReviewResponseDto> reviews = reviewService.getLatestReviews(page, size);
-        return ResponseEntity.ok(reviews);
-    }
+  @GetMapping("/reviews/latest")
+  public ResponseEntity<Page<ReviewResponseDto>> getLatestReviews(
+      @RequestParam("page") int page,
+      @RequestParam("size") int size
+  ) {
+    Page<ReviewResponseDto> reviews = reviewService.getLatestReviews(page, size);
+    return ResponseEntity.ok(reviews);
+  }
 
-    /**
-     * 특정 리뷰를 수정합니다
-     *
-     * @param reviewId         수정할 리뷰의 ID
-     * @param reviewRequestDto 클라이언트가 전달한 수정 데이터
-     * @param authentication   현재 인증된 사용자
-     * @return 수정된 리뷰의 상세 정보를 담은 DTO
-     */
-    @PutMapping(value = "/reviews/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<ReviewResponseDto> updateReview(
-            @PathVariable Long reviewId,
-            @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
-            @RequestPart(value = "images", required = false) List<MultipartFile> images,
-            Authentication authentication
-    ) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        ReviewResponseDto updatedReview = reviewService.updateReview(reviewId, reviewRequestDto, images, member);
+  /**
+   * 특정 리뷰를 수정합니다
+   *
+   * @param reviewId         수정할 리뷰의 ID
+   * @param reviewRequestDto 클라이언트가 전달한 수정 데이터
+   * @param authentication   현재 인증된 사용자
+   * @return 수정된 리뷰의 상세 정보를 담은 DTO
+   */
+  @PutMapping(value = "/reviews/{reviewId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ReviewResponseDto> updateReview(
+      @PathVariable Long reviewId,
+      @RequestPart(value = "data") ReviewRequestDto reviewRequestDto,
+      @RequestPart(value = "images", required = false) List<MultipartFile> images,
+      Authentication authentication
+  ) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    ReviewResponseDto updatedReview = reviewService.updateReview(reviewId, reviewRequestDto, images,
+        member);
 
-        return ResponseEntity.ok(updatedReview);
-    }
+    return ResponseEntity.ok(updatedReview);
+  }
 
-    /**
-     * 특정 리뷰를 삭제합니다
-     *
-     * @param reviewId       삭제할 리뷰의 ID
-     * @param authentication 현재 인증된 사용자
-     * @return 삭제 완료 메시지
-     */
-    @DeleteMapping("/reviews/{reviewId}")
-    public ResponseEntity<String> deleteReview(@PathVariable Long reviewId,
-                                               Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        reviewService.deleteReview(reviewId, member);
+  /**
+   * 특정 리뷰를 삭제합니다
+   *
+   * @param reviewId       삭제할 리뷰의 ID
+   * @param authentication 현재 인증된 사용자
+   * @return 삭제 완료 메시지
+   */
+  @DeleteMapping("/reviews/{reviewId}")
+  public ResponseEntity<String> deleteReview(@PathVariable Long reviewId,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    reviewService.deleteReview(reviewId, member);
 
-        return ResponseEntity.ok("리뷰가 성공적으로 삭제되었습니다.");
-    }
+    return ResponseEntity.ok("리뷰가 성공적으로 삭제되었습니다.");
+  }
 
-    @PostMapping("/reviews/{reviewId}/likes")
-    public ResponseEntity<String> likeReview(@PathVariable Long reviewId,
-                                             Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        reviewService.likeReview(reviewId, member);
+  @PostMapping("/reviews/{reviewId}/likes")
+  public ResponseEntity<String> likeReview(@PathVariable Long reviewId,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    reviewService.likeReview(reviewId, member);
 
-        return ResponseEntity.ok("좋아요 성공");
-    }
+    return ResponseEntity.ok("좋아요 성공");
+  }
 
-    @DeleteMapping("/reviews/{reviewId}/likes")
-    public ResponseEntity<String> unlikeReview(@PathVariable Long reviewId,
-                                               Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        reviewService.unlikeReview(reviewId, member);
-        return ResponseEntity.ok("좋아요 취소 성공");
-    }
+  @DeleteMapping("/reviews/{reviewId}/likes")
+  public ResponseEntity<String> unlikeReview(@PathVariable Long reviewId,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    reviewService.unlikeReview(reviewId, member);
+    return ResponseEntity.ok("좋아요 취소 성공");
+  }
 
-    @GetMapping("/books/{bookId}/reviews/friends")
-    public ResponseEntity<Page<ReviewResponseDto>> getFriendsReviews(
-            @PathVariable String bookId,
-            @RequestParam("page") int page,
-            @RequestParam("size") int size,
-            @RequestParam(value = "sortType", defaultValue = "likes") String sortType,
-            Authentication authentication) {
-        CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
-        Page<ReviewResponseDto> reviews = reviewService.getFriendsReviews(bookId, member, page, size, sortType);
-        return ResponseEntity.ok(reviews);
-    }
+  @GetMapping("/books/{bookId}/reviews/friends")
+  public ResponseEntity<Page<ReviewResponseDto>> getFriendsReviews(
+      @PathVariable String bookId,
+      @RequestParam("page") int page,
+      @RequestParam("size") int size,
+      @RequestParam(value = "sortType", defaultValue = "likes") String sortType,
+      Authentication authentication) {
+    CustomMemberDetails member = (CustomMemberDetails) authentication.getPrincipal();
+    Page<ReviewResponseDto> reviews = reviewService.getFriendsReviews(bookId, member, page, size,
+        sortType);
+    return ResponseEntity.ok(reviews);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewRequestDto.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 클라이언트로부터 전달받은 리뷰 생성/수정 데이터를 담는 DTO입니다
@@ -19,18 +21,15 @@ public class ReviewRequestDto {
 
     private String content;
 
-    /**
-     * DTO의 데이터를 이용해 Review 엔티티를 생성합니다
-     *
-     * @param book   리뷰와 연관된 책 엔티티
-     * @param member 리뷰 작성자 엔티티
-     * @return Review 엔티티
-     */
-    public Review toEntity(Book book, Member member) {
+    @Builder.Default
+    private List<String> imageUrls = new ArrayList<>();
+
+    public Review toEntity(Book book, Member member, List<String> imageUrls) {
         return Review.builder()
                 .content(content)
                 .book(book)
                 .member(member)
+                .imageUrls(imageUrls)
                 .build();
     }
 }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewRequestDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewRequestDto.java
@@ -3,12 +3,12 @@ package com.team1.epilogue.review.dto;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.review.entity.Review;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 클라이언트로부터 전달받은 리뷰 생성/수정 데이터를 담는 DTO입니다
@@ -19,17 +19,17 @@ import java.util.List;
 @Builder
 public class ReviewRequestDto {
 
-    private String content;
+  private String content;
 
-    @Builder.Default
-    private List<String> imageUrls = new ArrayList<>();
+  @Builder.Default
+  private List<String> imageUrls = new ArrayList<>();
 
-    public Review toEntity(Book book, Member member, List<String> imageUrls) {
-        return Review.builder()
-                .content(content)
-                .book(book)
-                .member(member)
-                .imageUrls(imageUrls)
-                .build();
-    }
+  public Review toEntity(Book book, Member member, List<String> imageUrls) {
+    return Review.builder()
+        .content(content)
+        .book(book)
+        .member(member)
+        .imageUrls(imageUrls)
+        .build();
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
@@ -1,11 +1,11 @@
 package com.team1.epilogue.review.dto;
 
 import com.team1.epilogue.review.entity.Review;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  * 클라이언트에게 전달할 리뷰 상세 정보를 담는 DTO입니다
@@ -14,37 +14,38 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class ReviewResponseDto {
-    private Long id;
-    private String content;
-    private String nickname;
-    private Long memberId;
-    private String memberProfileImage;
-    private LocalDateTime createdAt;
-    private LocalDateTime modifiedAt;
-    private int likeCount;
-    private int commentsCount;
-    private String bookTitle;
-    private List<String> imageUrls;
 
-    /**
-     * Review 엔티티를 DTO로 변환합니다
-     *
-     * @param review 변환할 Review 엔티티
-     * @return 변환된 ReviewResponseDto 객체
-     */
-    public static ReviewResponseDto from(Review review) {
-        return ReviewResponseDto.builder()
-                .id(review.getId())
-                .content(review.getContent())
-                .nickname(review.getMember().getNickname())
-                .memberId(review.getMember().getId())
-                .memberProfileImage(review.getMember().getProfileUrl())
-                .createdAt(review.getCreatedAt())
-                .modifiedAt(review.getModifiedAt())
-                .likeCount(review.getLikeCount())
-                .commentsCount(review.getCommentsCount())
-                .bookTitle(review.getBook().getTitle())
-                .imageUrls(review.getImageUrls())
-                .build();
-    }
+  private Long id;
+  private String content;
+  private String nickname;
+  private Long memberId;
+  private String memberProfileImage;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+  private int likeCount;
+  private int commentsCount;
+  private String bookTitle;
+  private List<String> imageUrls;
+
+  /**
+   * Review 엔티티를 DTO로 변환합니다
+   *
+   * @param review 변환할 Review 엔티티
+   * @return 변환된 ReviewResponseDto 객체
+   */
+  public static ReviewResponseDto from(Review review) {
+    return ReviewResponseDto.builder()
+        .id(review.getId())
+        .content(review.getContent())
+        .nickname(review.getMember().getNickname())
+        .memberId(review.getMember().getId())
+        .memberProfileImage(review.getMember().getProfileUrl())
+        .createdAt(review.getCreatedAt())
+        .modifiedAt(review.getModifiedAt())
+        .likeCount(review.getLikeCount())
+        .commentsCount(review.getCommentsCount())
+        .bookTitle(review.getBook().getTitle())
+        .imageUrls(review.getImageUrls())
+        .build();
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
@@ -4,8 +4,8 @@ import com.team1.epilogue.review.entity.Review;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
 import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * 클라이언트에게 전달할 리뷰 상세 정보를 담는 DTO입니다
@@ -24,6 +24,7 @@ public class ReviewResponseDto {
     private int likeCount;
     private int commentsCount;
     private String bookTitle;
+    private List<String> imageUrls;
 
     /**
      * Review 엔티티를 DTO로 변환합니다
@@ -43,6 +44,7 @@ public class ReviewResponseDto {
                 .likeCount(review.getLikeCount())
                 .commentsCount(review.getCommentsCount())
                 .bookTitle(review.getBook().getTitle())
+                .imageUrls(review.getImageUrls())
                 .build();
     }
 }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
@@ -18,9 +18,12 @@ public class ReviewResponseDto {
     private String content;
     private String nickname;
     private Long memberId;
+    private String memberProfileImage;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private int likeCount;
+    private int commentsCount;
+    private String bookTitle;
 
     /**
      * Review 엔티티를 DTO로 변환합니다
@@ -34,9 +37,12 @@ public class ReviewResponseDto {
                 .content(review.getContent())
                 .nickname(review.getMember().getNickname())
                 .memberId(review.getMember().getId())
+                .memberProfileImage(review.getMember().getProfileUrl())
                 .createdAt(review.getCreatedAt())
                 .modifiedAt(review.getModifiedAt())
                 .likeCount(review.getLikeCount())
+                .commentsCount(review.getCommentsCount())
+                .bookTitle(review.getBook().getTitle())
                 .build();
     }
 }

--- a/src/main/java/com/team1/epilogue/review/entity/Review.java
+++ b/src/main/java/com/team1/epilogue/review/entity/Review.java
@@ -4,14 +4,23 @@ import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.common.entity.BaseEntity;
 import com.team1.epilogue.review.service.StringListConverter;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -21,47 +30,47 @@ import java.util.List;
 @EntityListeners(AuditingEntityListener.class)
 public class Review extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    // 리뷰 작성자
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+  // 리뷰 작성자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
 
-    // 해당 리뷰가 속한 책
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "book_id", nullable = false)
-    private Book book;
+  // 해당 리뷰가 속한 책
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "book_id", nullable = false)
+  private Book book;
 
-    // 리뷰 내용
-    private String content;
+  // 리뷰 내용
+  private String content;
 
-    @Builder.Default
-    @Convert(converter = StringListConverter.class) //  변환기 적용
-    @Column(columnDefinition = "TEXT") //  길이 제한 없음
-    private List<String> imageUrls = new ArrayList<>();
+  @Builder.Default
+  @Convert(converter = StringListConverter.class) //  변환기 적용
+  @Column(columnDefinition = "TEXT") //  길이 제한 없음
+  private List<String> imageUrls = new ArrayList<>();
 
-    @Builder.Default
-    @Column(nullable = false)
-    private int likeCount = 0;
+  @Builder.Default
+  @Column(nullable = false)
+  private int likeCount = 0;
 
-    @Builder.Default
-    @Column(nullable = false)
-    private int commentsCount = 0; // 댓글 갯수
+  @Builder.Default
+  @Column(nullable = false)
+  private int commentsCount = 0; // 댓글 갯수
 
-    /**
-     * 리뷰 내용을 수정합니다
-     *
-     * @param content 수정할 새로운 내용
-     */
-    public void updateReview(String content) {
-        this.content = content;
-    }
+  /**
+   * 리뷰 내용을 수정합니다
+   *
+   * @param content 수정할 새로운 내용
+   */
+  public void updateReview(String content) {
+    this.content = content;
+  }
 
-    public void updateImageUrls(List<String> imageUrls) {
-        this.imageUrls = imageUrls;
-    }
+  public void updateImageUrls(List<String> imageUrls) {
+    this.imageUrls = imageUrls;
+  }
 }
 

--- a/src/main/java/com/team1/epilogue/review/entity/Review.java
+++ b/src/main/java/com/team1/epilogue/review/entity/Review.java
@@ -3,12 +3,15 @@ package com.team1.epilogue.review.entity;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.common.entity.BaseEntity;
+import com.team1.epilogue.review.service.StringListConverter;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -35,9 +38,10 @@ public class Review extends BaseEntity {
     // 리뷰 내용
     private String content;
 
-    // 리뷰에 첨부된 이미지 URL
-    @Column(name = "image_url")
-    private String imageUrl;
+    @Builder.Default
+    @Convert(converter = StringListConverter.class) //  변환기 적용
+    @Column(columnDefinition = "TEXT") //  길이 제한 없음
+    private List<String> imageUrls = new ArrayList<>();
 
     @Builder.Default
     @Column(nullable = false)
@@ -54,6 +58,10 @@ public class Review extends BaseEntity {
      */
     public void updateReview(String content) {
         this.content = content;
+    }
+
+    public void updateImageUrls(List<String> imageUrls) {
+        this.imageUrls = imageUrls;
     }
 }
 

--- a/src/main/java/com/team1/epilogue/review/entity/Review.java
+++ b/src/main/java/com/team1/epilogue/review/entity/Review.java
@@ -14,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 public class Review extends BaseEntity {
@@ -44,6 +43,10 @@ public class Review extends BaseEntity {
     @Column(nullable = false)
     private int likeCount = 0;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private int commentsCount = 0; // 댓글 갯수
+
     /**
      * 리뷰 내용을 수정합니다
      *
@@ -52,7 +55,5 @@ public class Review extends BaseEntity {
     public void updateReview(String content) {
         this.content = content;
     }
-
-    private int commentsCount; // 댓글 갯수
 }
 

--- a/src/main/java/com/team1/epilogue/review/entity/ReviewLike.java
+++ b/src/main/java/com/team1/epilogue/review/entity/ReviewLike.java
@@ -2,7 +2,13 @@ package com.team1.epilogue.review.entity;
 
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.common.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,20 +19,20 @@ import lombok.NoArgsConstructor;
 @Entity
 public class ReviewLike extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id", nullable = false)
-    private Review review;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "review_id", nullable = false)
+  private Review review;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
 
-    public ReviewLike(Review review, Member member) {
-        this.review = review;
-        this.member = member;
-    }
+  public ReviewLike(Review review, Member member) {
+    this.review = review;
+    this.member = member;
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/AlreadyLikedException.java
+++ b/src/main/java/com/team1/epilogue/review/exception/AlreadyLikedException.java
@@ -1,7 +1,8 @@
 package com.team1.epilogue.review.exception;
 
-public class AlreadyLikedException extends RuntimeException{
-    public AlreadyLikedException(String message) {
-        super(message);
-    }
+public class AlreadyLikedException extends RuntimeException {
+
+  public AlreadyLikedException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/BookNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/review/exception/BookNotFoundException.java
@@ -4,7 +4,8 @@ package com.team1.epilogue.review.exception;
  * 특정 책을 찾을 수 없을 때 발생하는 예외
  */
 public class BookNotFoundException extends RuntimeException {
-    public BookNotFoundException(String message) {
-        super(message);
-    }
+
+  public BookNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/LikeNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/review/exception/LikeNotFoundException.java
@@ -1,7 +1,8 @@
 package com.team1.epilogue.review.exception;
 
-public class LikeNotFoundException extends RuntimeException{
-    public LikeNotFoundException(String message) {
-        super(message);
-    }
+public class LikeNotFoundException extends RuntimeException {
+
+  public LikeNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/ReviewExceptionHandler.java
+++ b/src/main/java/com/team1/epilogue/review/exception/ReviewExceptionHandler.java
@@ -12,46 +12,47 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ReviewExceptionHandler {
 
-    /**
-     * 책을 찾을 수 없을 때 예외 처리
-     */
-    @ExceptionHandler(BookNotFoundException.class)
-    public ResponseEntity<String> handleBookNotFoundException(BookNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+  /**
+   * 책을 찾을 수 없을 때 예외 처리
+   */
+  @ExceptionHandler(BookNotFoundException.class)
+  public ResponseEntity<String> handleBookNotFoundException(BookNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
 
-    /**
-     * 리뷰를 찾을 수 없을 때 예외 처리
-     */
-    @ExceptionHandler(ReviewNotFoundException.class)
-    public ResponseEntity<String> handleReviewNotFoundException(ReviewNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+  /**
+   * 리뷰를 찾을 수 없을 때 예외 처리
+   */
+  @ExceptionHandler(ReviewNotFoundException.class)
+  public ResponseEntity<String> handleReviewNotFoundException(ReviewNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
 
-    /**
-     * 리뷰 작성자가 아닌 사용자가 수정/삭제하려 할 때 예외 처리
-     */
-    @ExceptionHandler(UnauthorizedReviewAccessException.class)
-    public ResponseEntity<String> handleUnauthorizedReviewAccessException(UnauthorizedReviewAccessException e) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
-    }
+  /**
+   * 리뷰 작성자가 아닌 사용자가 수정/삭제하려 할 때 예외 처리
+   */
+  @ExceptionHandler(UnauthorizedReviewAccessException.class)
+  public ResponseEntity<String> handleUnauthorizedReviewAccessException(
+      UnauthorizedReviewAccessException e) {
+    return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+  }
 
-    /**
-     * 해당 별점을 찾을 수 없을 때 예외 처리
-     */
-    @ExceptionHandler(RatingNotFoundException.class)
-    public ResponseEntity<String> handleRatingNotFoundException(RatingNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+  /**
+   * 해당 별점을 찾을 수 없을 때 예외 처리
+   */
+  @ExceptionHandler(RatingNotFoundException.class)
+  public ResponseEntity<String> handleRatingNotFoundException(RatingNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
 
-    @ExceptionHandler(LikeNotFoundException.class)
-    public ResponseEntity<String> handleRatingNotFoundException(LikeNotFoundException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+  @ExceptionHandler(LikeNotFoundException.class)
+  public ResponseEntity<String> handleRatingNotFoundException(LikeNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
 
 
-    @ExceptionHandler(AlreadyLikedException.class)
-    public ResponseEntity<String> handleRatingNotFoundException(AlreadyLikedException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
-    }
+  @ExceptionHandler(AlreadyLikedException.class)
+  public ResponseEntity<String> handleRatingNotFoundException(AlreadyLikedException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/ReviewNotFoundException.java
+++ b/src/main/java/com/team1/epilogue/review/exception/ReviewNotFoundException.java
@@ -3,8 +3,9 @@ package com.team1.epilogue.review.exception;
 /**
  * 특정 리뷰를 찾을 수 없을 때 발생하는 예외
  */
-public class ReviewNotFoundException extends RuntimeException{
-    public ReviewNotFoundException(String message) {
-        super(message);
-    }
+public class ReviewNotFoundException extends RuntimeException {
+
+  public ReviewNotFoundException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/exception/UnauthorizedReviewAccessException.java
+++ b/src/main/java/com/team1/epilogue/review/exception/UnauthorizedReviewAccessException.java
@@ -4,7 +4,8 @@ package com.team1.epilogue.review.exception;
  * 리뷰 수정 또는 삭제 권한이 없는 사용자가 접근할 때 발생하는 예외
  */
 public class UnauthorizedReviewAccessException extends RuntimeException {
-    public UnauthorizedReviewAccessException(String message) {
-        super(message);
-    }
+
+  public UnauthorizedReviewAccessException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewLikeRepository.java
@@ -1,13 +1,13 @@
 package com.team1.epilogue.review.repository;
 
 import com.team1.epilogue.review.entity.ReviewLike;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
-    Optional<ReviewLike> findByReviewIdAndMemberId(Long reviewId, Long memberId);
 
-    Boolean existsByReviewIdAndMemberId(Long reviewId, Long memberId);
+  Optional<ReviewLike> findByReviewIdAndMemberId(Long reviewId, Long memberId);
+
+  Boolean existsByReviewIdAndMemberId(Long reviewId, Long memberId);
 
 }

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
@@ -3,60 +3,73 @@ package com.team1.epilogue.review.repository;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.review.entity.Review;
 import io.lettuce.core.dynamic.annotation.Param;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.member WHERE r.book.id = :bookId")
-  Page<Review> findByBookIdWithMember(@Param("bookId") String bookId, Pageable pageable);
+    // 특정 책의 리뷰 전체 조회 (Member, Book 함께 조회, 페이징 적용)
+    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.book.id = :bookId")
+    Page<Review> findByBookIdWithMember(@Param("bookId") String bookId, Pageable pageable);
 
-  @Modifying
-  @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
-  int increaseLikeCount(@Param("reviewId") Long reviewId);
+    // 특정 리뷰 상세 조회 (Member, Book 함께 조회)
+    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.id = :reviewId")
+    Optional<Review> findByIdWithBookAndMember(@Param("reviewId") Long reviewId);
 
-  @Modifying
-  @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
-  int decreaseLikeCount(@Param("reviewId") Long reviewId);
+    // 최신 리뷰 목록 조회 (Member, Book 함께 조회, 최신순 정렬, 페이징 적용)
+    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member ORDER BY r.createdAt DESC")
+    Page<Review> findAllReviewsSortedByLatest(Pageable pageable);
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member "
-      + "WHERE r.createdAt BETWEEN :startDate AND :endDate AND r.member.loginId = :memberId")
-  List<Review> findByDateAndMember(
-      @Param("startDate") LocalDateTime startDate,
-      @Param("endDate") LocalDateTime endDate,
-      @Param("memberId") String memberId);
+    // 리뷰 좋아요 증가 (좋아요 개수를 직접 업데이트)
+    @Modifying
+    @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
+    int increaseLikeCount(@Param("reviewId") Long reviewId);
 
-  Page<Review> findByBookId(String bookId, Pageable pageable);
+    // 리뷰 좋아요 감소 (최소 0 유지, 직접 업데이트)
+    @Modifying
+    @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
+    int decreaseLikeCount(@Param("reviewId") Long reviewId);
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b " +
-          "WHERE r.book.id = :bookId AND m IN :members")
-  Page<Review> findByBookIdAndMemberInWithFetchJoin(@Param("bookId") String bookId,
-                                                    @Param("members") Iterable<Member> members,
-                                                    Pageable pageable);
+    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member "
+            + "WHERE r.createdAt BETWEEN :startDate AND :endDate AND r.member.loginId = :memberId")
+    List<Review> findByDateAndMember(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("memberId") String memberId);
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.member m WHERE m IN :members")
-  Page<Review> findByMemberInWithFetchJoin(@Param("members") Iterable<Member> members,
-      Pageable pageable);
+    Page<Review> findByBookId(String bookId, Pageable pageable);
 
-  @Modifying
-  @Query("UPDATE Review r SET r.commentsCount = r.commentsCount + 1 WHERE r.id = :reviewId")
-  int increaseCommentsCount(@Param("reviewId") Long reviewId);
+    @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b " +
+            "WHERE r.book.id = :bookId AND m IN :members")
+    Page<Review> findByBookIdAndMemberInWithFetchJoin(@Param("bookId") String bookId,
+                                                      @Param("members") Iterable<Member> members,
+                                                      Pageable pageable);
 
-  @Modifying
-  @Query("UPDATE Review r SET r.commentsCount = r.commentsCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
-  int decreaseCommentsCount(@Param("reviewId") Long reviewId);
+    @Query("SELECT r FROM Review r JOIN FETCH r.member m WHERE m IN :members")
+    Page<Review> findByMemberInWithFetchJoin(@Param("members") Iterable<Member> members,
+                                             Pageable pageable);
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member WHERE r.member.id =:memberID")
-  Page<Review> findByMemberId(@Param("memberID") String id, Pageable pageable);
+    @Modifying
+    @Query("UPDATE Review r SET r.commentsCount = r.commentsCount + 1 WHERE r.id = :reviewId")
+    int increaseCommentsCount(@Param("reviewId") Long reviewId);
 
-  @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b WHERE b.id = :bookId AND m IN :members")
-  Page<Review> findFriendReviewsByBookIdAndMemberIn(@Param("bookId") String bookId,
-                                                    @Param("members") Iterable<Member> members,
-                                                    Pageable pageable);
+    @Modifying
+    @Query("UPDATE Review r SET r.commentsCount = r.commentsCount - 1 WHERE r.id = :reviewId AND r.commentsCount > 0")
+    int decreaseCommentsCount(@Param("reviewId") Long reviewId);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member WHERE r.member.id =:memberID")
+    Page<Review> findByMemberId(@Param("memberID") String id, Pageable pageable);
+
+    @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b WHERE b.id = :bookId AND m IN :members")
+    Page<Review> findFriendReviewsByBookIdAndMemberIn(@Param("bookId") String bookId,
+                                                      @Param("members") Iterable<Member> members,
+                                                      Pageable pageable);
 
 }

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
@@ -3,73 +3,72 @@ package com.team1.epilogue.review.repository;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.review.entity.Review;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
-
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    // 특정 책의 리뷰 전체 조회 (Member, Book 함께 조회, 페이징 적용)
-    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.book.id = :bookId")
-    Page<Review> findByBookIdWithMember(@Param("bookId") String bookId, Pageable pageable);
+  // 특정 책의 리뷰 전체 조회 (Member, Book 함께 조회, 페이징 적용)
+  @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.book.id = :bookId")
+  Page<Review> findByBookIdWithMember(@Param("bookId") String bookId, Pageable pageable);
 
-    // 특정 리뷰 상세 조회 (Member, Book 함께 조회)
-    @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.id = :reviewId")
-    Optional<Review> findByIdWithBookAndMember(@Param("reviewId") Long reviewId);
+  // 특정 리뷰 상세 조회 (Member, Book 함께 조회)
+  @Query("SELECT r FROM Review r JOIN FETCH r.member JOIN FETCH r.book WHERE r.id = :reviewId")
+  Optional<Review> findByIdWithBookAndMember(@Param("reviewId") Long reviewId);
 
-    // 최신 리뷰 목록 조회 (Member, Book 함께 조회, 최신순 정렬, 페이징 적용)
-    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member ORDER BY r.createdAt DESC")
-    Page<Review> findAllReviewsSortedByLatest(Pageable pageable);
+  // 최신 리뷰 목록 조회 (Member, Book 함께 조회, 최신순 정렬, 페이징 적용)
+  @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member ORDER BY r.createdAt DESC")
+  Page<Review> findAllReviewsSortedByLatest(Pageable pageable);
 
-    // 리뷰 좋아요 증가 (좋아요 개수를 직접 업데이트)
-    @Modifying
-    @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
-    int increaseLikeCount(@Param("reviewId") Long reviewId);
+  // 리뷰 좋아요 증가 (좋아요 개수를 직접 업데이트)
+  @Modifying
+  @Query("UPDATE Review r SET r.likeCount = r.likeCount + 1 WHERE r.id = :reviewId")
+  int increaseLikeCount(@Param("reviewId") Long reviewId);
 
-    // 리뷰 좋아요 감소 (최소 0 유지, 직접 업데이트)
-    @Modifying
-    @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
-    int decreaseLikeCount(@Param("reviewId") Long reviewId);
+  // 리뷰 좋아요 감소 (최소 0 유지, 직접 업데이트)
+  @Modifying
+  @Query("UPDATE Review r SET r.likeCount = r.likeCount - 1 WHERE r.id = :reviewId AND r.likeCount > 0")
+  int decreaseLikeCount(@Param("reviewId") Long reviewId);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member "
-            + "WHERE r.createdAt BETWEEN :startDate AND :endDate AND r.member.loginId = :memberId")
-    List<Review> findByDateAndMember(
-            @Param("startDate") LocalDateTime startDate,
-            @Param("endDate") LocalDateTime endDate,
-            @Param("memberId") String memberId);
+  @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member "
+      + "WHERE r.createdAt BETWEEN :startDate AND :endDate AND r.member.loginId = :memberId")
+  List<Review> findByDateAndMember(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("memberId") String memberId);
 
-    Page<Review> findByBookId(String bookId, Pageable pageable);
+  Page<Review> findByBookId(String bookId, Pageable pageable);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b " +
-            "WHERE r.book.id = :bookId AND m IN :members")
-    Page<Review> findByBookIdAndMemberInWithFetchJoin(@Param("bookId") String bookId,
-                                                      @Param("members") Iterable<Member> members,
-                                                      Pageable pageable);
+  @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b " +
+      "WHERE r.book.id = :bookId AND m IN :members")
+  Page<Review> findByBookIdAndMemberInWithFetchJoin(@Param("bookId") String bookId,
+      @Param("members") Iterable<Member> members,
+      Pageable pageable);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.member m WHERE m IN :members")
-    Page<Review> findByMemberInWithFetchJoin(@Param("members") Iterable<Member> members,
-                                             Pageable pageable);
+  @Query("SELECT r FROM Review r JOIN FETCH r.member m WHERE m IN :members")
+  Page<Review> findByMemberInWithFetchJoin(@Param("members") Iterable<Member> members,
+      Pageable pageable);
 
-    @Modifying
-    @Query("UPDATE Review r SET r.commentsCount = r.commentsCount + 1 WHERE r.id = :reviewId")
-    int increaseCommentsCount(@Param("reviewId") Long reviewId);
+  @Modifying
+  @Query("UPDATE Review r SET r.commentsCount = r.commentsCount + 1 WHERE r.id = :reviewId")
+  int increaseCommentsCount(@Param("reviewId") Long reviewId);
 
-    @Modifying
-    @Query("UPDATE Review r SET r.commentsCount = r.commentsCount - 1 WHERE r.id = :reviewId AND r.commentsCount > 0")
-    int decreaseCommentsCount(@Param("reviewId") Long reviewId);
+  @Modifying
+  @Query("UPDATE Review r SET r.commentsCount = r.commentsCount - 1 WHERE r.id = :reviewId AND r.commentsCount > 0")
+  int decreaseCommentsCount(@Param("reviewId") Long reviewId);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member WHERE r.member.id =:memberID")
-    Page<Review> findByMemberId(@Param("memberID") String id, Pageable pageable);
+  @Query("SELECT r FROM Review r JOIN FETCH r.book JOIN FETCH r.member WHERE r.member.id =:memberID")
+  Page<Review> findByMemberId(@Param("memberID") String id, Pageable pageable);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b WHERE b.id = :bookId AND m IN :members")
-    Page<Review> findFriendReviewsByBookIdAndMemberIn(@Param("bookId") String bookId,
-                                                      @Param("members") Iterable<Member> members,
-                                                      Pageable pageable);
+  @Query("SELECT r FROM Review r JOIN FETCH r.member m JOIN FETCH r.book b WHERE b.id = :bookId AND m IN :members")
+  Page<Review> findFriendReviewsByBookIdAndMemberIn(@Param("bookId") String bookId,
+      @Param("members") Iterable<Member> members,
+      Pageable pageable);
 
 }

--- a/src/main/java/com/team1/epilogue/review/service/ReviewService.java
+++ b/src/main/java/com/team1/epilogue/review/service/ReviewService.java
@@ -13,9 +13,16 @@ import com.team1.epilogue.review.dto.ReviewRequestDto;
 import com.team1.epilogue.review.dto.ReviewResponseDto;
 import com.team1.epilogue.review.entity.Review;
 import com.team1.epilogue.review.entity.ReviewLike;
-import com.team1.epilogue.review.exception.*;
+import com.team1.epilogue.review.exception.AlreadyLikedException;
+import com.team1.epilogue.review.exception.BookNotFoundException;
+import com.team1.epilogue.review.exception.LikeNotFoundException;
+import com.team1.epilogue.review.exception.ReviewNotFoundException;
+import com.team1.epilogue.review.exception.UnauthorizedReviewAccessException;
 import com.team1.epilogue.review.repository.ReviewLikeRepository;
 import com.team1.epilogue.review.repository.ReviewRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,180 +31,189 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
 
-    private final ReviewRepository reviewRepository;
-    private final BookRepository bookRepository;
-    private final ReviewLikeRepository reviewLikeRepository;
-    private final MemberRepository memberRepository;
-    private final FollowRepository followRepository;
-    private final S3Service s3Service;
+  private final ReviewRepository reviewRepository;
+  private final BookRepository bookRepository;
+  private final ReviewLikeRepository reviewLikeRepository;
+  private final MemberRepository memberRepository;
+  private final FollowRepository followRepository;
+  private final S3Service s3Service;
 
 
-    @Transactional
-    public ReviewResponseDto createReview(String bookId, ReviewRequestDto reviewRequestDto, List<MultipartFile> images, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Book book = bookRepository.findById(bookId)
-                .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
+  @Transactional
+  public ReviewResponseDto createReview(String bookId, ReviewRequestDto reviewRequestDto,
+      List<MultipartFile> images, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Book book = bookRepository.findById(bookId)
+        .orElseThrow(() -> new BookNotFoundException("존재하지 않는 책입니다."));
 
-        if (images != null && images.size() > 5) {
-            throw new IllegalArgumentException("최대 5개의 이미지만 업로드할 수 있습니다.");
+    if (images != null && images.size() > 5) {
+      throw new IllegalArgumentException("최대 5개의 이미지만 업로드할 수 있습니다.");
+    }
+
+    // 여러 개의 이미지 업로드 처리
+    List<String> imageUrls = new ArrayList<>();
+    if (images != null && !images.isEmpty()) {
+      for (MultipartFile image : images) {
+        if (image != null && !image.isEmpty()) {
+          String imageUrl = s3Service.uploadFile(image);
+          imageUrls.add(imageUrl);
         }
+      }
+    }
 
-        // 여러 개의 이미지 업로드 처리
-        List<String> imageUrls = new ArrayList<>();
-        if (images != null && !images.isEmpty()) {
-            for (MultipartFile image : images) {
-                if (image != null && !image.isEmpty()) {
-                    String imageUrl = s3Service.uploadFile(image);
-                    imageUrls.add(imageUrl);
-                }
-            }
+    Review review = reviewRequestDto.toEntity(book, member, imageUrls);
+    reviewRepository.save(review);
+
+    return ReviewResponseDto.from(review);
+  }
+
+  public Page<ReviewResponseDto> getReviews(String bookId, int page, int size, String sortType) {
+    Pageable pageable = createPageable(page, size, sortType);
+    Page<Review> reviews = reviewRepository.findByBookIdWithMember(bookId, pageable);
+
+    return reviews.map(ReviewResponseDto::from);
+  }
+
+  private Pageable createPageable(int page, int size, String sortType) {
+    Sort sort = sortType.equals("likes")
+        ? Sort.by(Sort.Direction.DESC, "likeCount").and(Sort.by(Sort.Direction.DESC, "createdAt"))
+        : Sort.by(Sort.Direction.DESC, "createdAt");
+
+    return PageRequest.of(page - 1, size, sort);
+  }
+
+  public ReviewResponseDto getReviewDetail(Long reviewId) {
+    Review review = reviewRepository.findByIdWithBookAndMember(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+    return ReviewResponseDto.from(review);
+  }
+
+  public Page<ReviewResponseDto> getLatestReviews(int page, int size) {
+    Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<Review> reviews = reviewRepository.findAllReviewsSortedByLatest(pageable);
+    return reviews.map(ReviewResponseDto::from);
+  }
+
+  @Transactional
+  public ReviewResponseDto updateReview(Long reviewId, ReviewRequestDto reviewRequestDto,
+      List<MultipartFile> images, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+    if (!review.getMember().getId().equals(member.getId())) {
+      throw new UnauthorizedReviewAccessException("리뷰 작성자만 수정할 수 있습니다.");
+    }
+
+    review.updateReview(reviewRequestDto.getContent());
+
+    List<String> existingImageUrls = new ArrayList<>(review.getImageUrls());
+    List<String> updatedImageUrls = new ArrayList<>();
+
+    // 기존 이미지 유지 여부 확인 (기본값: 빈 리스트)
+    List<String> imageUrlsToKeep =
+        (reviewRequestDto.getImageUrls() != null) ? reviewRequestDto.getImageUrls()
+            : new ArrayList<>();
+
+    for (String imageUrl : existingImageUrls) {
+      if (imageUrlsToKeep.contains(imageUrl)) { // 기존 이미지 유지 확인
+        updatedImageUrls.add(imageUrl);
+      } else {
+        s3Service.deleteFile(imageUrl); // 삭제할 이미지는 S3에서도 삭제
+      }
+    }
+
+    // 새로운 이미지 업로드
+    if (images != null && !images.isEmpty()) {
+      if (updatedImageUrls.size() + images.size() > 5) {
+        throw new IllegalArgumentException("최대 5개의 이미지만 업로드할 수 있습니다.");
+      }
+
+      for (MultipartFile image : images) {
+        if (image != null && !image.isEmpty()) {
+          String imageUrl = s3Service.uploadFile(image);
+          updatedImageUrls.add(imageUrl);
         }
-
-        Review review = reviewRequestDto.toEntity(book, member, imageUrls);
-        reviewRepository.save(review);
-
-        return ReviewResponseDto.from(review);
+      }
     }
 
-    public Page<ReviewResponseDto> getReviews(String bookId, int page, int size, String sortType) {
-        Pageable pageable = createPageable(page, size, sortType);
-        Page<Review> reviews = reviewRepository.findByBookIdWithMember(bookId, pageable);
+    // 항상 업데이트 (이미지 변경 여부와 상관없이)
+    review.updateImageUrls(updatedImageUrls);
 
-        return reviews.map(ReviewResponseDto::from);
+    return ReviewResponseDto.from(review);
+  }
+
+  public void deleteReview(Long reviewId, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+    if (!review.getMember().getId().equals(member.getId())) {
+      throw new UnauthorizedReviewAccessException("리뷰 작성자만 삭제할 수 있습니다.");
     }
 
-    private Pageable createPageable(int page, int size, String sortType) {
-        Sort sort = sortType.equals("likes")
-                ? Sort.by(Sort.Direction.DESC, "likeCount").and(Sort.by(Sort.Direction.DESC, "createdAt"))
-                : Sort.by(Sort.Direction.DESC, "createdAt");
+    reviewRepository.delete(review);
+  }
 
-        return PageRequest.of(page - 1, size, sort);
+  @Transactional
+  public void likeReview(Long reviewId, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+    if (reviewLikeRepository.existsByReviewIdAndMemberId(reviewId, member.getId())) {
+      throw new AlreadyLikedException("이미 좋아요를 눌렀습니다.");
     }
 
-    public ReviewResponseDto getReviewDetail(Long reviewId) {
-        Review review = reviewRepository.findByIdWithBookAndMember(reviewId)
-                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+    ReviewLike reviewLike = new ReviewLike(review, member);
+    reviewLikeRepository.save(reviewLike);
 
-        return ReviewResponseDto.from(review);
+    reviewRepository.increaseLikeCount(reviewId);
+  }
+
+  @Transactional
+  public void unlikeReview(Long reviewId, CustomMemberDetails memberDetails) {
+    Member member = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    ReviewLike reviewLike = reviewLikeRepository.findByReviewIdAndMemberId(reviewId, member.getId())
+        .orElseThrow(() -> new LikeNotFoundException("취소할 좋아요가 없습니다."));
+
+    reviewLikeRepository.delete(reviewLike);
+
+    reviewRepository.decreaseLikeCount(reviewId);
+  }
+
+  public Page<ReviewResponseDto> getFriendsReviews(String bookId, CustomMemberDetails memberDetails,
+      int page, int size, String sortType) {
+    Member currentMember = memberRepository.findById(memberDetails.getId())
+        .orElseThrow(
+            () -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
+    List<Follow> followings = followRepository.findByFollowerWithFollowed(currentMember);
+    List<Member> friendMembers = followings.stream()
+        .map(Follow::getFollowed)
+        .collect(Collectors.toList());
+
+    if (friendMembers.isEmpty()) {
+      return Page.empty();
     }
-
-    public Page<ReviewResponseDto> getLatestReviews(int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        Page<Review> reviews = reviewRepository.findAllReviewsSortedByLatest(pageable);
-        return reviews.map(ReviewResponseDto::from);
-    }
-
-    @Transactional
-    public ReviewResponseDto updateReview(Long reviewId, ReviewRequestDto reviewRequestDto, List<MultipartFile> images, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
-
-        if (!review.getMember().getId().equals(member.getId())) {
-            throw new UnauthorizedReviewAccessException("리뷰 작성자만 수정할 수 있습니다.");
-        }
-
-        review.updateReview(reviewRequestDto.getContent());
-
-        List<String> existingImageUrls = new ArrayList<>(review.getImageUrls());
-        List<String> updatedImageUrls = new ArrayList<>();
-
-        // 기존 이미지 유지 여부 확인 (기본값: 빈 리스트)
-        List<String> imageUrlsToKeep = (reviewRequestDto.getImageUrls() != null) ? reviewRequestDto.getImageUrls() : new ArrayList<>();
-
-        for (String imageUrl : existingImageUrls) {
-            if (imageUrlsToKeep.contains(imageUrl)) { // 기존 이미지 유지 확인
-                updatedImageUrls.add(imageUrl);
-            } else {
-                s3Service.deleteFile(imageUrl); // 삭제할 이미지는 S3에서도 삭제
-            }
-        }
-
-        // 새로운 이미지 업로드
-        if (images != null && !images.isEmpty()) {
-            if (updatedImageUrls.size() + images.size() > 5) {
-                throw new IllegalArgumentException("최대 5개의 이미지만 업로드할 수 있습니다.");
-            }
-
-            for (MultipartFile image : images) {
-                if (image != null && !image.isEmpty()) {
-                    String imageUrl = s3Service.uploadFile(image);
-                    updatedImageUrls.add(imageUrl);
-                }
-            }
-        }
-
-        // 항상 업데이트 (이미지 변경 여부와 상관없이)
-        review.updateImageUrls(updatedImageUrls);
-
-        return ReviewResponseDto.from(review);
-    }
-
-    public void deleteReview(Long reviewId, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
-
-        if (!review.getMember().getId().equals(member.getId())) {
-            throw new UnauthorizedReviewAccessException("리뷰 작성자만 삭제할 수 있습니다.");
-        }
-
-        reviewRepository.delete(review);
-    }
-
-    @Transactional
-    public void likeReview(Long reviewId, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
-
-        if (reviewLikeRepository.existsByReviewIdAndMemberId(reviewId, member.getId())) {
-            throw new AlreadyLikedException("이미 좋아요를 눌렀습니다.");
-        }
-
-        ReviewLike reviewLike = new ReviewLike(review, member);
-        reviewLikeRepository.save(reviewLike);
-
-        reviewRepository.increaseLikeCount(reviewId);
-    }
-
-    @Transactional
-    public void unlikeReview(Long reviewId, CustomMemberDetails memberDetails) {
-        Member member = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        ReviewLike reviewLike = reviewLikeRepository.findByReviewIdAndMemberId(reviewId, member.getId())
-                .orElseThrow(() -> new LikeNotFoundException("취소할 좋아요가 없습니다."));
-
-        reviewLikeRepository.delete(reviewLike);
-
-        reviewRepository.decreaseLikeCount(reviewId);
-    }
-
-    public Page<ReviewResponseDto> getFriendsReviews(String bookId, CustomMemberDetails memberDetails, int page, int size, String sortType) {
-        Member currentMember = memberRepository.findById(memberDetails.getId())
-                .orElseThrow(() -> new MemberNotFoundException("ID가 " + memberDetails.getId() + "인 회원을 찾을 수 없습니다."));
-        List<Follow> followings = followRepository.findByFollowerWithFollowed(currentMember);
-        List<Member> friendMembers = followings.stream()
-                .map(Follow::getFollowed)
-                .collect(Collectors.toList());
-
-        if (friendMembers.isEmpty()) {
-            return Page.empty();
-        }
-        Pageable pageable = createPageable(page, size, sortType);
-        Page<Review> reviews = reviewRepository.findByBookIdAndMemberInWithFetchJoin(bookId, friendMembers, pageable);
-        return reviews.map(ReviewResponseDto::from);
-    }
+    Pageable pageable = createPageable(page, size, sortType);
+    Page<Review> reviews = reviewRepository.findByBookIdAndMemberInWithFetchJoin(bookId,
+        friendMembers, pageable);
+    return reviews.map(ReviewResponseDto::from);
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/service/StringListConverter.java
+++ b/src/main/java/com/team1/epilogue/review/service/StringListConverter.java
@@ -10,23 +10,25 @@ import java.util.List;
 @Converter
 public class StringListConverter implements AttributeConverter<List<String>, String> {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Override
-    public String convertToDatabaseColumn(List<String> attribute) {
-        try {
-            return (attribute == null || attribute.isEmpty()) ? null : objectMapper.writeValueAsString(attribute);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("List<String> 변환 실패", e);
-        }
+  @Override
+  public String convertToDatabaseColumn(List<String> attribute) {
+    try {
+      return (attribute == null || attribute.isEmpty()) ? null
+          : objectMapper.writeValueAsString(attribute);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("List<String> 변환 실패", e);
     }
+  }
 
-    @Override
-    public List<String> convertToEntityAttribute(String dbData) {
-        try {
-            return (dbData == null || dbData.isEmpty()) ? List.of() : Arrays.asList(objectMapper.readValue(dbData, String[].class));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("DB 데이터 -> List<String> 변환 실패", e);
-        }
+  @Override
+  public List<String> convertToEntityAttribute(String dbData) {
+    try {
+      return (dbData == null || dbData.isEmpty()) ? List.of()
+          : Arrays.asList(objectMapper.readValue(dbData, String[].class));
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("DB 데이터 -> List<String> 변환 실패", e);
     }
+  }
 }

--- a/src/main/java/com/team1/epilogue/review/service/StringListConverter.java
+++ b/src/main/java/com/team1/epilogue/review/service/StringListConverter.java
@@ -1,0 +1,32 @@
+package com.team1.epilogue.review.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.List;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        try {
+            return (attribute == null || attribute.isEmpty()) ? null : objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("List<String> 변환 실패", e);
+        }
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        try {
+            return (dbData == null || dbData.isEmpty()) ? List.of() : Arrays.asList(objectMapper.readValue(dbData, String[].class));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("DB 데이터 -> List<String> 변환 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## **변경사항**

### 모든 책의 리뷰를 최신순으로 조회하는 API 추가 (`api/reviews/latest`)

### 리뷰 조회 시 응답 데이터 개선
✅ 추가된 응답 필드
  - 작성자 프로필 이미지 (`memberProfileImage`)
  - 댓글 개수 (`commentsCount`
  - 책 제목 (`bookTitle`)
  - 리뷰 이미지 리스트(`imageUrls`)
![_리뷰최신순이거](https://github.com/user-attachments/assets/b77fc291-d1e8-4817-9352-c1aff195b672)

 ### 리뷰 작성 및 수정 시 이미지를 업로드 기능 추가
- Review 엔티티에 `imageUrls` 필드 추가 및 JSON 변환 적용
- `StringListConverter` 생성 및 적용하여 리스트 형태의 이미지 URL 저장
- 리뷰 생성(`createReview`), 수정(`updateReview`) 시 이미지 리스트 반영 
- `ReviewDto` 및 관련 DTO의 `imageUrl` → `imageUrls` (리스트 형태)로 변경


![_리뷰생성이미지3개](https://github.com/user-attachments/assets/d7152aa6-0116-4522-ab5a-d7d7444c99fe)


