### PR TITLE
fix: 회원가입 시 프로필 이미지 업로드되지 않은 경우 profileUrl이 null로 셋팅

### DIFF
--- a/src/main/java/com/team1/epilogue/auth/service/MemberService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
             throw new EmailAlreadyExistException();
         }
 
-        String profileUrl = request.getProfileUrl();
+        String profileUrl = null;
         if (profileImage != null && !profileImage.isEmpty()) {
             profileUrl = s3StorageService.uploadFile(profileImage);
         }

--- a/src/main/java/com/team1/epilogue/auth/service/MemberService.java
+++ b/src/main/java/com/team1/epilogue/auth/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
             throw new EmailAlreadyExistException();
         }
 
-        String profileUrl = null;
+        String profileUrl = "";
         if (profileImage != null && !profileImage.isEmpty()) {
             profileUrl = s3StorageService.uploadFile(profileImage);
         }


### PR DESCRIPTION
## **변경사항**
  - 기존에 form-data의 "data" 파트를 JSON으로 인코딩하여 전송하던 로직을 제거하였습니다.
  - 전송 시 원래의 form-data 형식(즉, JSON 인코딩 없이 순수한 텍스트 데이터)을 유지하도록 수정하였습니다.
---
## **리뷰 요청 사항**
  - 변경된 multipart form-data 생성 로직과 관련하여 boundary 및 데이터 형식이 올바르게 처리되고 있는지 검토 부탁드립니다.
  - 기존 라이브러리의 JSON 인코딩 제거로 인해 다른 부분에 부작용은 없는지 추가 테스트가 필요합니다.
  - 코드의 가독성과 유지보수성을 위해 추가적인 주석이나 리팩토링이 필요한 부분이 있는지 확인해 주세요.
---
## **관련된 이슈**
- S3 이미지 업로드와 관련되 회원가입, 수정 기능 전반  #15
---
리뷰 부탁드립니다!
