### PR TITLE
feat : 마이페이지 내부 유저 정보주는 메서드 추가

### DIFF
--- a/src/main/java/com/team1/epilogue/collection/repository/CollectionRepository.java
+++ b/src/main/java/com/team1/epilogue/collection/repository/CollectionRepository.java
@@ -25,4 +25,6 @@ public interface CollectionRepository extends JpaRepository<CollectionEntity,Lon
   void deleteByMemberAndBookId(@Param("memberId") Long memberId, @Param("bookId") String bookId);
 
   boolean existsByMemberAndBook(Member member, Book book);
+
+  int countAllByMember(Member member);
 }

--- a/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team1/epilogue/comment/repository/CommentRepository.java
@@ -32,4 +32,6 @@ public interface CommentRepository extends JpaRepository<Comment,Long> {
   @Modifying
   @Query("UPDATE Comment c SET c.likeCount = c.likeCount - 1 WHERE c.id = :commentId AND c.likeCount > 0")
   int decreaseLikeCount(@Param("commentId") Long commentId);
+
+  int countAllByMember(Member member);
 }

--- a/src/main/java/com/team1/epilogue/config/SecurityConfig.java
+++ b/src/main/java/com/team1/epilogue/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.team1.epilogue.auth.security.JwtAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
@@ -20,6 +21,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import java.util.List;
 import org.springframework.web.cors.CorsConfiguration;
@@ -103,7 +105,8 @@ public class SecurityConfig {
                             "/api/books/detail",
                             "/api/reviews/latest",
                             "/api/books/{bookId}/reviews",
-                            "/api/reviews/**"
+                            "/api/reviews/**",
+                            "/api/mypage/user-info"
                     ).permitAll()
                 .requestMatchers(HttpMethod.DELETE, "/api/reviews/**").authenticated()
                 .requestMatchers(HttpMethod.PUT, "/api/reviews/**").authenticated()
@@ -112,7 +115,8 @@ public class SecurityConfig {
 
             )
             .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, memberRepository), UsernamePasswordAuthenticationFilter.class)
-            .oauth2Login(withDefaults())
+            .oauth2Login(withDefaults()).exceptionHandling( ex -> ex.authenticationEntryPoint(new HttpStatusEntryPoint(
+            HttpStatus.UNAUTHORIZED)))
             .httpBasic(httpBasic -> httpBasic.disable());
     return http.build();
   }

--- a/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
+++ b/src/main/java/com/team1/epilogue/follow/repository/FollowRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 /**
  * [클래스 레벨]
  * FollowRepository는 회원 간의 팔로우 관계를 관리하는 JPA 리포지토리이
- *
  * 주요 기능:
  * - 특정 회원이 특정 회원을 팔로우했는지 확인
  * - 특정 회원이 팔로우한 회원 목록 조회
@@ -33,4 +32,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     // Fetch Join: 팔로우 대상을 함께 로딩 (팔로잉 목록)
     @Query("select f from Follow f join fetch f.followed where f.follower = :follower")
     List<Follow> findByFollowerWithFollowed(@Param("follower") Member follower);
+
+    int countAllByFollowed(Member member);
+    int countAllByFollower(Member member);
 }

--- a/src/main/java/com/team1/epilogue/gathering/repository/JoinMeetingRepository.java
+++ b/src/main/java/com/team1/epilogue/gathering/repository/JoinMeetingRepository.java
@@ -25,6 +25,8 @@ public interface JoinMeetingRepository extends JpaRepository<JoinMeeting, Long> 
 
   @EntityGraph(attributePaths = {"meeting","meeting.book"})
   Page<JoinMeeting> findAllByMember_LoginId(String memberLoginId,Pageable page);
+
+  int countAllByMember(Member member);
 }
 
 

--- a/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
+++ b/src/main/java/com/team1/epilogue/mypage/controller/MyPageController.java
@@ -5,6 +5,7 @@ import com.team1.epilogue.mypage.dto.MyPageCalendarResponse;
 import com.team1.epilogue.mypage.dto.MyPageCommentsResponse;
 import com.team1.epilogue.mypage.dto.MyPageMeetingResponse;
 import com.team1.epilogue.mypage.dto.MyPageReviewsResponse;
+import com.team1.epilogue.mypage.dto.MyPageUserInfo;
 import com.team1.epilogue.mypage.service.MyPageService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -49,8 +50,9 @@ public class MyPageController {
 
   /**
    * 마이 페이지 내부 "해당 유저의 캘린더 보기" 기능을 위한 메서드
+   *
    * @param memberId 조회할 유저의 ID
-   * @param date 조회할 월
+   * @param date     조회할 월
    */
   @GetMapping("/api/mypage/calendar")
   public ResponseEntity<List<MyPageCalendarResponse>> getCalendar(@RequestParam String memberId,
@@ -61,8 +63,9 @@ public class MyPageController {
 
   /**
    * 마이 페이지 내부 "해당 유저의 모임 기록 보기" 기능을 위한 메서드
+   *
    * @param memberId 조회할 유저의 ID
-   * @param page 조회할 페이지
+   * @param page     조회할 페이지
    */
   @GetMapping("/api/mypage/meeting")
   public ResponseEntity<MyPageMeetingResponse> getMeetingByMember(
@@ -71,5 +74,13 @@ public class MyPageController {
   ) {
     MyPageMeetingResponse response = myPageService.getMeetings(memberId, page);
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/api/mypage/user-info")
+  public ResponseEntity<MyPageUserInfo> getMemberInfoData(
+      @RequestParam String memberId
+  ) {
+    MyPageUserInfo memberData = myPageService.getMemberData(memberId);
+    return ResponseEntity.ok(memberData);
   }
 }

--- a/src/main/java/com/team1/epilogue/mypage/dto/MyPageUserInfo.java
+++ b/src/main/java/com/team1/epilogue/mypage/dto/MyPageUserInfo.java
@@ -1,0 +1,20 @@
+package com.team1.epilogue.mypage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyPageUserInfo {
+  private String nickName;
+  private String loginId;
+  private String email;
+  private int follower;
+  private int following;
+  private int reviewCount;
+  private int commentCount;
+  private int meetingCount;
+  private int collectionCount;
+  private int point;
+
+}

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewRepository.java
@@ -71,4 +71,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
       @Param("members") Iterable<Member> members,
       Pageable pageable);
 
+  int countAllByMember(Member member);
+
 }


### PR DESCRIPTION
- **변경사항**
    - 마이페이지 내부의 유저 데이터를 주는 기능 작업하였습니다.
 
# 출력 예시
```
{
"nickName": "bird",
"loginId": "test123",
"email": "[test@naver.com](mailto:test@naver.com)",
"follower": "20",
"following": "30",
"reviewCount": "22",
"commentCount": "50",
"meetingCount": "10",
"collectionCount": "100",
"point": "9500"
}
```

- **리뷰 요청 사항**
    - 위 기능에대한 코드 리뷰 부탁드립니다.

