### PR TITLE
refactor: auth, follow, share 기능 통합 테스트 리팩토링

### DIFF
--- a/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/AuthControllerTest.java
@@ -17,12 +17,16 @@ import com.team1.epilogue.auth.service.GoogleWithdrawalService;
 import com.team1.epilogue.auth.service.KakaoWithdrawalService;
 import com.team1.epilogue.auth.service.LogoutService;
 import com.team1.epilogue.auth.service.MemberWithdrawalService;
+import com.team1.epilogue.config.TestMongoConfig;
 import com.team1.epilogue.config.TestSecurityConfig;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -32,42 +36,55 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
-@WebMvcTest(AuthController.class)
-@Import(TestSecurityConfig.class)
+@WebMvcTest(controllers = AuthController.class,
+        excludeAutoConfiguration = {MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
+@Import({TestSecurityConfig.class, TestMongoConfig.class})
 @DisplayName("AuthController 테스트")
-@RequiredArgsConstructor
 public class AuthControllerTest {
 
-
+    @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
     private ObjectMapper objectMapper;
 
     @MockitoBean
     private AuthService authService;
+
     @MockitoBean
     private KakaoAuthService kakaoAuthService;
+
     @MockitoBean
     private GoogleAuthService googleAuthService;
+
     @MockitoBean
     private MemberWithdrawalService memberWithdrawalService;
+
     @MockitoBean
     private GoogleWithdrawalService googleWithdrawalService;
+
     @MockitoBean
     private KakaoWithdrawalService kakaoWithdrawalService;
+
     @MockitoBean
     private LogoutService logoutService;
+
+
+    // 추가: JPA 메타모델 관련 빈 모의 객체 제공
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @Test
     @DisplayName("로그인 성공")
@@ -241,7 +258,6 @@ public class AuthControllerTest {
                 .andExpect(jsonPath("$.success", is(true)))
                 .andExpect(jsonPath("$.data.message", is("Social Logout Success")));
     }
-
 
     @Test
     @DisplayName("소셜 회원 탈퇴 성공")

--- a/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
+++ b/src/test/java/com/team1/epilogue/auth/controller/MemberControllerTest.java
@@ -3,23 +3,27 @@ package com.team1.epilogue.auth.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.team1.epilogue.auth.dto.MemberResponse;
 import com.team1.epilogue.auth.dto.RegisterRequest;
-import com.team1.epilogue.auth.dto.SuccessResponse;
 import com.team1.epilogue.auth.dto.UpdateMemberRequest;
 import com.team1.epilogue.auth.entity.Member;
 import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.auth.service.MemberService;
 import com.team1.epilogue.auth.service.MemberWithdrawalService;
+import com.team1.epilogue.config.TestMongoConfig;
 import com.team1.epilogue.config.TestSecurityConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -40,8 +44,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@Import(TestSecurityConfig.class)
-@WebMvcTest(MemberController.class)
+@WebMvcTest(controllers = MemberController.class)
+@Import({TestSecurityConfig.class, TestMongoConfig.class})
 @DisplayName("MemberController 테스트")
 public class MemberControllerTest {
 
@@ -50,6 +54,9 @@ public class MemberControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @MockitoBean
     private MemberService memberService;

--- a/src/test/java/com/team1/epilogue/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/team1/epilogue/chat/service/ChatRoomServiceTest.java
@@ -80,7 +80,7 @@ class ChatRoomServiceTest {
   void createRoom_Success() {
     when(memberRepository.findById(1L)).thenReturn(Optional.of(new Member()));
     when(bookRepository.findByTitle("Book Title")).thenReturn(Optional.empty());
-    when(bookService.getBookDetail(any()))
+    when(bookService.getBookDetail(any(), any()))
         .thenReturn(BookDetailResponse.builder().title("Book Title").build());
     when(bookService.insertBookInfo(any())).thenReturn(new Book());
     when(chatRoomRepository.findByTitle(any())).thenReturn(Optional.empty());

--- a/src/test/java/com/team1/epilogue/config/JpaConfig.java
+++ b/src/test/java/com/team1/epilogue/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.team1.epilogue.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/test/java/com/team1/epilogue/config/TestMongoConfig.java
+++ b/src/test/java/com/team1/epilogue/config/TestMongoConfig.java
@@ -1,0 +1,13 @@
+package com.team1.epilogue.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
+
+@Configuration
+public class TestMongoConfig {
+    @Bean
+    public MongoMappingContext mongoMappingContext() {
+        return new MongoMappingContext();
+    }
+}

--- a/src/test/java/com/team1/epilogue/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/team1/epilogue/follow/controller/FollowControllerTest.java
@@ -1,6 +1,8 @@
 package com.team1.epilogue.follow.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.team1.epilogue.config.TestMongoConfig;
+import com.team1.epilogue.config.TestSecurityConfig;
 import com.team1.epilogue.follow.dto.FollowActionResponse;
 import com.team1.epilogue.follow.dto.MembersResponse;
 import com.team1.epilogue.follow.dto.MessageResponse;
@@ -14,6 +16,8 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FollowController.class)
+@Import({TestSecurityConfig.class, TestMongoConfig.class})
 @DisplayName("FollowController 테스트")
 @RequiredArgsConstructor
 public class FollowControllerTest {
@@ -37,6 +42,8 @@ public class FollowControllerTest {
     @MockitoBean
     private FollowService followService;
     private ObjectMapper objectMapper;
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/team1/epilogue/follow/service/FollowServiceTest.java
+++ b/src/test/java/com/team1/epilogue/follow/service/FollowServiceTest.java
@@ -6,35 +6,50 @@ import com.team1.epilogue.book.entity.Book;
 import com.team1.epilogue.book.repository.BookRepository;
 import com.team1.epilogue.follow.dto.FollowActionResponse;
 import com.team1.epilogue.follow.dto.MemberDto;
+import com.team1.epilogue.follow.dto.PaginationDto;
 import com.team1.epilogue.follow.dto.ReviewDto;
 import com.team1.epilogue.follow.dto.ReviewListResponse;
 import com.team1.epilogue.follow.entity.Follow;
 import com.team1.epilogue.follow.repository.FollowRepository;
 import com.team1.epilogue.review.entity.Review;
 import com.team1.epilogue.review.repository.ReviewRepository;
-import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@Transactional
-@DisplayName("FollowService 통합 테스트")
-@RequiredArgsConstructor
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FollowService 단위 테스트")
 class FollowServiceTest {
 
+    @Mock
     private MemberRepository memberRepository;
-    private BookRepository bookRepository;
+
+    @Mock
     private FollowRepository followRepository;
+
+    @Mock
     private ReviewRepository reviewRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @InjectMocks
     private FollowService followService;
 
     private Member follower;
@@ -42,42 +57,43 @@ class FollowServiceTest {
 
     @BeforeEach
     void setUp() {
-        memberRepository.deleteAll();
-        followRepository.deleteAll();
-        reviewRepository.deleteAll();
-
-        // 테스트용 회원 데이터 생성
         follower = Member.builder()
+                .id(1L)
                 .loginId("user1")
                 .password("password1")
                 .name("User One")
                 .nickname("User One")
                 .profileUrl("http://example.com/user1.png")
                 .birthDate(LocalDate.of(1990, 1, 1))
-                .email("user12@example.com")
+                .email("user1@example.com")
                 .phone("010-1234-5678")
-                .point(0)
                 .build();
 
         followed = Member.builder()
+                .id(2L)
                 .loginId("user2")
                 .password("password2")
                 .name("User Two")
                 .nickname("User Two")
                 .profileUrl("http://example.com/user2.png")
                 .birthDate(LocalDate.of(1992, 2, 2))
-                .email("user22@example.com")
+                .email("user2@example.com")
                 .phone("010-8765-4321")
-                .point(0)
                 .build();
-
-        memberRepository.save(follower);
-        memberRepository.save(followed);
     }
 
     @Test
     @DisplayName("팔로우 생성 성공 테스트")
     void testFollowUser_success() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        when(followRepository.findByFollowerAndFollowed(follower, followed)).thenReturn(Optional.empty());
+
+        Follow savedFollow = new Follow();
+        savedFollow.setFollower(follower);
+        savedFollow.setFollowed(followed);
+        when(followRepository.save(any(Follow.class))).thenReturn(savedFollow);
+
         FollowActionResponse response = followService.followUser("user1", "user2");
         assertNotNull(response);
         assertEquals("Follow creation successful", response.getMessage());
@@ -88,8 +104,17 @@ class FollowServiceTest {
     @Test
     @DisplayName("이미 팔로우 중인 경우 예외 발생 테스트")
     void testFollowUser_alreadyFollowing() {
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow existingFollow = new Follow();
+        existingFollow.setFollower(follower);
+        existingFollow.setFollowed(followed);
+        when(followRepository.findByFollowerAndFollowed(follower, followed))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(existingFollow));
+
         followService.followUser("user1", "user2");
-        Exception exception = assertThrows(ResponseStatusException.class, () -> {
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class, () -> {
             followService.followUser("user1", "user2");
         });
         assertTrue(exception.getMessage().contains("Already following"));
@@ -98,52 +123,64 @@ class FollowServiceTest {
     @Test
     @DisplayName("팔로우 삭제 성공 테스트")
     void testUnfollowUser_success() {
-        followService.followUser("user1", "user2");
-        followService.unfollowUser("user1", "user2");
-        List<Follow> follows = followRepository.findByFollower(follower);
-        assertTrue(follows.isEmpty());
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow follow = new Follow();
+        follow.setFollower(follower);
+        follow.setFollowed(followed);
+        when(followRepository.findByFollowerAndFollowed(follower, followed)).thenReturn(Optional.of(follow));
+
+        assertDoesNotThrow(() -> followService.unfollowUser("user1", "user2"));
     }
 
     @Test
     @DisplayName("팔로잉 목록 조회 성공 테스트")
     void testGetFollowingList_success() {
-        followService.followUser("user1", "user2");
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        Follow follow = new Follow();
+        follow.setFollowed(followed);
+        when(followRepository.findByFollowerWithFollowed(follower)).thenReturn(List.of(follow));
+
         List<MemberDto> followingList = followService.getFollowingList("user1");
         assertEquals(1, followingList.size());
         MemberDto dto = followingList.get(0);
+        assertEquals(String.valueOf(followed.getId()), dto.getId());
         assertEquals("user2", dto.getLoginId());
     }
 
     @Test
-    @DisplayName("팔로워 목록 조회 성공 테스트 (Fetch Join 적용)")
+    @DisplayName("팔로워 목록 조회 성공 테스트")
     void testGetFollowersList_success() {
-        followService.followUser("user1", "user2");
+        when(memberRepository.findByLoginId("user2")).thenReturn(Optional.of(followed));
+        Follow follow = new Follow();
+        follow.setFollower(follower);
+        when(followRepository.findByFollowedWithFollower(followed)).thenReturn(List.of(follow));
+
         List<MemberDto> followersList = followService.getFollowersList("user2");
         assertEquals(1, followersList.size());
         MemberDto dto = followersList.get(0);
+        assertEquals(String.valueOf(follower.getId()), dto.getId());
         assertEquals("user1", dto.getLoginId());
     }
 
     @Test
     @DisplayName("팔로우한 회원의 리뷰 조회 성공 테스트")
     void testGetFollowedReviews_success() {
-        followService.followUser("user1", "user2");
-
-        Book testBook = Book.builder()
-                .id("1")
-                .title("Test Book")
-                .build();
-
-     bookRepository.save(testBook);
+        when(memberRepository.findByLoginId("user1")).thenReturn(Optional.of(follower));
+        Follow follow = new Follow();
+        follow.setFollower(follower);
+        follow.setFollowed(followed);
+        when(followRepository.findByFollower(follower)).thenReturn(List.of(follow));
 
         Review review = Review.builder()
                 .member(followed)
-                .book(testBook)
+                // Book 정보는 reviewRepository.findByMemberInWithFetchJoin의 파라미터로 처리됨
                 .content("Test review content")
-//                .imageUrl("http://example.com/image.png")
-//                .createdAt(LocalDateTime.now())
                 .build();
-        reviewRepository.save(review);
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by("createdAt").descending());
+        Page<Review> reviewPage = new PageImpl<>(List.of(review), pageable, 1);
+        when(reviewRepository.findByMemberInWithFetchJoin(List.of(followed), pageable)).thenReturn(reviewPage);
 
         ReviewListResponse response = followService.getFollowedReviews("user1", 1, 10, "desc");
         assertNotNull(response);

--- a/src/test/java/com/team1/epilogue/share/ShareControllerTest.java
+++ b/src/test/java/com/team1/epilogue/share/ShareControllerTest.java
@@ -1,13 +1,21 @@
 package com.team1.epilogue.share;
 
 import com.team1.epilogue.book.repository.BookRepository;
+import com.team1.epilogue.config.TestMongoConfig;
+import com.team1.epilogue.config.TestSecurityConfig;
+import com.team1.epilogue.follow.controller.FollowController;
 import com.team1.epilogue.review.repository.ReviewRepository;
+import com.team1.epilogue.share.controller.ShareController;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -16,14 +24,17 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@WebMvcTest(controllers = ShareController.class)
+@Import({TestSecurityConfig.class, TestMongoConfig.class})
 @DisplayName("ShareController 테스트")
+@RequiredArgsConstructor
 public class ShareControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
     @MockitoBean
     private BookRepository bookRepository;
@@ -42,7 +53,7 @@ public class ShareControllerTest {
                         .param("id", bookId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shareUrl").value("https://13.125.112.89/books/" + bookId));
+                .andExpect(jsonPath("$.shareUrl").value("http://localhost:8080/books/" + bookId));
     }
 
     @Test
@@ -56,7 +67,7 @@ public class ShareControllerTest {
                         .param("id", reviewId)
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.shareUrl").value("https://13.125.112.89/reviews/" + reviewId));
+                .andExpect(jsonPath("$.shareUrl").value("http://localhost:8080/reviews/" + reviewId));
     }
 
     @Test


### PR DESCRIPTION
## **변경사항**
- AuthController, FollowController, ShareController 관련 통합 테스트 코드를 리팩토링하였습니다.
- 불필요한 JPA/MongoDB 구성을 통해 테스트 환경을 구축했습니다.
- JpaMetamodelMappingContext 모의 객체를 추가하여 JPA 메타모델 관련 오류를 해결했습니다.
- 테스트 대상 URL, 파라미터, 응답 검증 로직 등을 개선하여 가독성과 유지보수성을 높였습니다.
---

## **리뷰 요청 사항**
- 통합 테스트가 실제 기능(로그인, 팔로우, 공유 URL 생성 등)을 올바르게 검증하고 있는지 확인 부탁드립니다.
- CI/CD 환경에 문제 없이 적용 되는지 검토해 주시기 바랍니다.
- 테스트 코드의 가독성과 유지보수성(메서드명, 변수명, 검증 로직 등)에 대한 피드백 부탁드립니다.
---

## **관련된 이슈**
- #15
- #21
- #23
---

리뷰 부탁드립니다!