### PR TITLE
feat: 책 상세 응답에 내 별점(myRating) 추가 및 리뷰 목록에 좋아요 여부 포함

### DIFF
--- a/src/main/java/com/team1/epilogue/book/dto/BookDetailResponse.java
+++ b/src/main/java/com/team1/epilogue/book/dto/BookDetailResponse.java
@@ -20,5 +20,5 @@ public class BookDetailResponse {
   private double avgRating;
   private List<SameAuthorBookTitleIsbn> sameAuthor;
   private boolean existCollection;
-
+  private Double myRating;
 }

--- a/src/main/java/com/team1/epilogue/book/service/BookService.java
+++ b/src/main/java/com/team1/epilogue/book/service/BookService.java
@@ -17,6 +17,7 @@ import com.team1.epilogue.book.repository.BookRepository;
 import com.team1.epilogue.book.repository.CustomBookRepository;
 import com.team1.epilogue.collection.repository.CollectionRepository;
 import com.team1.epilogue.keyword.service.KeyWordService;
+import com.team1.epilogue.rating.entity.Rating;
 import com.team1.epilogue.rating.repository.RatingRepository;
 import com.team1.epilogue.trendingbook.service.TrendingBookService;
 import java.time.LocalDate;
@@ -71,6 +72,7 @@ public class BookService {
     Optional<Book> bookOpt; // repository 에서 가져올 Optional 객체
     Book book; // Optional 내부의 책 데이터
     boolean existCollection = false;
+    Double myRating = null;
 
     if ("d_isbn".equals(type)) { // dto 의 Type 에 따라 다른 쿼리문 호출
       bookOpt = bookRepository.findById(query); // 책 ISBN 으로 DB 조회
@@ -126,9 +128,14 @@ public class BookService {
     if (jwt != null && jwt.startsWith("Bearer ")) {
       String token = jwt.substring(7);
       String memberIdFromJWT = jwtTokenProvider.getMemberIdFromJWT(token);
+      Long memberId = Long.parseLong(memberIdFromJWT);
       existCollection = collectionRepository.existsByMember_IdAndBook_Id(
-          Long.parseLong(memberIdFromJWT),
+          memberId,
           book.getId());
+
+      myRating = ratingRepository.findByMemberIdAndBookId(memberId, book.getId())
+          .map(Rating::getScore)
+          .orElse(null);
     }
 
     // DTO 로 반환 형식에 맞춰 return
@@ -144,6 +151,7 @@ public class BookService {
         .isbn(book.getId())
         .avgRating(avgRating != null ? avgRating : 0.0)
         .sameAuthor(dtoList)
+        .myRating(myRating)
         .build();
 
     return build;

--- a/src/main/java/com/team1/epilogue/book/service/BookService.java
+++ b/src/main/java/com/team1/epilogue/book/service/BookService.java
@@ -151,7 +151,7 @@ public class BookService {
         .isbn(book.getId())
         .avgRating(avgRating != null ? avgRating : 0.0)
         .sameAuthor(dtoList)
-        .myRating(myRating)
+        .myRating(myRating != null ? myRating : 0.0)
         .build();
 
     return build;

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -82,10 +82,14 @@ public class ReviewController {
    * @return 해당 리뷰의 상세 정보를 담은 DTO
    */
   @GetMapping("/reviews/{reviewId}")
-  public ResponseEntity<ReviewResponseDto> getReviewDetail(@PathVariable Long reviewId) {
-    ReviewResponseDto reviewResponseDto = reviewService.getReviewDetail(reviewId);
+  public ResponseEntity<ReviewResponseDto> getReviewDetail(
+      @PathVariable Long reviewId,
+      HttpServletRequest request
+  ) {
+    String token = request.getHeader("Authorization");
+    ReviewResponseDto dto = reviewService.getReviewDetail(reviewId, token);
 
-    return ResponseEntity.ok(reviewResponseDto);
+    return ResponseEntity.ok(dto);
   }
 
   @GetMapping("/reviews/latest")

--- a/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
+++ b/src/main/java/com/team1/epilogue/review/controller/ReviewController.java
@@ -4,6 +4,7 @@ import com.team1.epilogue.auth.security.CustomMemberDetails;
 import com.team1.epilogue.review.dto.ReviewRequestDto;
 import com.team1.epilogue.review.dto.ReviewResponseDto;
 import com.team1.epilogue.review.service.ReviewService;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -65,9 +66,11 @@ public class ReviewController {
       @PathVariable String bookId,
       @RequestParam("page") int page,
       @RequestParam("size") int size,
-      @RequestParam(value = "sortType", defaultValue = "likes") String sortType
+      @RequestParam(value = "sortType", defaultValue = "likes") String sortType,
+      HttpServletRequest request
   ) {
-    Page<ReviewResponseDto> reviews = reviewService.getReviews(bookId, page, size, sortType);
+    String token = request.getHeader("Authorization");
+    Page<ReviewResponseDto> reviews = reviewService.getReviews(bookId, page, size, sortType, token);
 
     return ResponseEntity.ok(reviews);
   }

--- a/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/team1/epilogue/review/dto/ReviewResponseDto.java
@@ -27,6 +27,7 @@ public class ReviewResponseDto {
   private String bookTitle;
   private String bookCoverUrl;
   private List<String> imageUrls;
+  private boolean liked;
 
   /**
    * Review 엔티티를 DTO로 변환합니다
@@ -49,5 +50,9 @@ public class ReviewResponseDto {
         .bookCoverUrl(review.getBook().getCoverUrl())
         .imageUrls(review.getImageUrls())
         .build();
+  }
+
+  public void setLiked(boolean liked) {
+    this.liked = liked;
   }
 }

--- a/src/main/java/com/team1/epilogue/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/com/team1/epilogue/review/repository/ReviewLikeRepository.java
@@ -1,8 +1,10 @@
 package com.team1.epilogue.review.repository;
 
 import com.team1.epilogue.review.entity.ReviewLike;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
@@ -10,4 +12,7 @@ public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
   Boolean existsByReviewIdAndMemberId(Long reviewId, Long memberId);
 
+  // 로그인한 사용자가 좋아요한 리뷰 ID들을 한 번의 쿼리로 조회 (N+1 문제 방지)
+  @Query("SELECT rl.review.id FROM ReviewLike rl WHERE rl.member.id = :memberId AND rl.review.id IN :reviewIds")
+  List<Long> findLikedReviewIdsByMemberId(Long memberId, List<Long> reviewIds);
 }

--- a/src/test/java/com/team1/epilogue/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/team1/epilogue/chat/service/ChatRoomServiceTest.java
@@ -80,7 +80,7 @@ class ChatRoomServiceTest {
   void createRoom_Success() {
     when(memberRepository.findById(1L)).thenReturn(Optional.of(new Member()));
     when(bookRepository.findByTitle("Book Title")).thenReturn(Optional.empty());
-    when(bookService.getBookDetail(any(), any()))
+    when(bookService.getBookDetail(any(), any(), null))
         .thenReturn(BookDetailResponse.builder().title("Book Title").build());
     when(bookService.insertBookInfo(any())).thenReturn(new Book());
     when(chatRoomRepository.findByTitle(any())).thenReturn(Optional.empty());

--- a/src/test/java/com/team1/epilogue/review/ReviewServiceTest.java
+++ b/src/test/java/com/team1/epilogue/review/ReviewServiceTest.java
@@ -147,7 +147,7 @@ public class ReviewServiceTest {
         reviewPage);
 
     // when
-    Page<ReviewResponseDto> response = reviewService.getReviews(testBook.getId(), 1, 10, sortType);
+    Page<ReviewResponseDto> response = reviewService.getReviews(testBook.getId(), 1, 10, sortType, null);
 
     // then
     assertThat(response.getTotalElements()).isEqualTo(1);
@@ -162,7 +162,7 @@ public class ReviewServiceTest {
         Optional.of(testReview));
 
     // when
-    ReviewResponseDto response = reviewService.getReviewDetail(testReview.getId());
+    ReviewResponseDto response = reviewService.getReviewDetail(testReview.getId(), null);
 
     // then
     assertThat(response.getId()).isEqualTo(testReview.getId());
@@ -176,7 +176,7 @@ public class ReviewServiceTest {
     when(reviewRepository.findByIdWithBookAndMember(anyLong())).thenReturn(Optional.empty());
 
     // when & then
-    assertThrows(ReviewNotFoundException.class, () -> reviewService.getReviewDetail(999L));
+    assertThrows(ReviewNotFoundException.class, () -> reviewService.getReviewDetail(999L, null));
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
- 로그인 사용자의 별점(myRating) 응답에 포함
- 별점 미등록 시 0.0으로 처리
- 리뷰 전체 목록/상세 조회 응답에 로그인 사용자의 좋아요 여부(`liked`) 포함

---


### ❤️ 좋아요 여부 테스트
- 로그인 사용자가 리뷰에 좋아요 눌렀는지 확인 가능
![_좋아요여부](https://github.com/user-attachments/assets/5e87677e-922b-4b8a-8742-f6c21cf32ebd)

<br>

### ⭐별점 테스트
- 로그인 사용자가 매긴 별점 포함 (`myRating`)
- 별점 없을 시 `0.0`으로 응답
![_별점매겼을때이거이거](https://github.com/user-attachments/assets/17cdac75-9d8d-4dc8-948e-d2af8aa93e5b)


--- 

### N+1 문제발생
- 리뷰 마다 `existsByReviewIdAndMemberId()` 실행 -> N+1문제
- 리뷰 8개 조회 시, 쿼리 8번 발생
![_엔플러스일](https://github.com/user-attachments/assets/b65ae904-2862-4e6d-88b7-a8427dc692cf)



### 해결 후 
- 좋아요한 리뷰 ID를 한 번에 조회하여 `Map`으로 처리
![_엔플러스일해결](https://github.com/user-attachments/assets/1840b265-b3e7-4f70-ae92-10bba64feafc)

